### PR TITLE
[WIP] Synchronize MPM tuning conf file with Perl's

### DIFF
--- a/5.5/contrib/etc/conf.d/50-mpm-tuning.conf.template
+++ b/5.5/contrib/etc/conf.d/50-mpm-tuning.conf.template
@@ -1,12 +1,13 @@
 <IfModule mpm_prefork_module>
     # This value should mirror what is set in MinSpareServers.
-    StartServers          ${HTTPD_START_SERVERS}
-    MinSpareServers       ${HTTPD_START_SERVERS}
-    MaxSpareServers       ${HTTPD_MAX_SPARE_SERVERS}
-    # The MaxRequestWorkers directive sets the limit on the number of simultaneous requests that will be served. 
-    # The default value, when no Cgroup limits are set is 256.
-    MaxRequestWorkers     ${HTTPD_MAX_REQUEST_WORKERS}
-    ServerLimit           ${HTTPD_MAX_REQUEST_WORKERS}
-    MaxRequestsPerChild   4000
-    MaxKeepAliveRequests  100
+    StartServers            ${HTTPD_START_SERVERS}
+    MinSpareServers         ${HTTPD_START_SERVERS}
+    MaxSpareServers         ${HTTPD_MAX_SPARE_SERVERS}
+    # The MaxRequestWorkers directive sets the limit on the number of
+    # simultaneous requests that will be served.
+    # The default value, when no cgroup limits are set is 256.
+    MaxRequestWorkers       ${HTTPD_MAX_REQUEST_WORKERS}
+    ServerLimit             ${HTTPD_MAX_REQUEST_WORKERS}
+    MaxConnectionsPerChild  4000
+    MaxKeepAliveRequests    100
 </IfModule>

--- a/5.6/contrib/etc/conf.d/50-mpm-tuning.conf.template
+++ b/5.6/contrib/etc/conf.d/50-mpm-tuning.conf.template
@@ -1,12 +1,13 @@
 <IfModule mpm_prefork_module>
     # This value should mirror what is set in MinSpareServers.
-    StartServers          ${HTTPD_START_SERVERS}
-    MinSpareServers       ${HTTPD_START_SERVERS}
-    MaxSpareServers       ${HTTPD_MAX_SPARE_SERVERS}
-    # The MaxRequestWorkers directive sets the limit on the number of simultaneous requests that will be served. 
-    # The default value, when no Cgroup limits are set is 256.
-    MaxRequestWorkers     ${HTTPD_MAX_REQUEST_WORKERS}
-    ServerLimit           ${HTTPD_MAX_REQUEST_WORKERS}
-    MaxRequestsPerChild   4000
-    MaxKeepAliveRequests  100
+    StartServers            ${HTTPD_START_SERVERS}
+    MinSpareServers         ${HTTPD_START_SERVERS}
+    MaxSpareServers         ${HTTPD_MAX_SPARE_SERVERS}
+    # The MaxRequestWorkers directive sets the limit on the number of
+    # simultaneous requests that will be served.
+    # The default value, when no cgroup limits are set is 256.
+    MaxRequestWorkers       ${HTTPD_MAX_REQUEST_WORKERS}
+    ServerLimit             ${HTTPD_MAX_REQUEST_WORKERS}
+    MaxConnectionsPerChild  4000
+    MaxKeepAliveRequests    100
 </IfModule>


### PR DESCRIPTION
MaxRequestsPerChild has been renamed to MaxConnectionsPerChild in
Apache 2.4.

I was also thinking about limiting the `HTTPD_MAX_REQUEST_WORKERS` as done in the Perl PR. I'm a bit afraid of setting it, by accident, to a much higher value than would be appropriate. We also do not allow it to be set explicitly (if you set a limit, it will be overwritten).

@mfojtik @bparees, thoughts? I'd like to add those changes as proposed into this PR, but wanted to consult before doing the work. See here for the code I'd like to use: https://github.com/mnagy/sti-perl/blob/7f4ffecbf0efda7d4c13041581bf55e8bd2786d4/5.16/s2i/bin/run#L20-L36