### PR TITLE
Changes for rhel7.2 build.

### DIFF
--- a/5.5/Dockerfile.rhel7
+++ b/5.5/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-FROM openshift/base-rhel7
+FROM registry.access.redhat.com/rhscl/s2i-base-rhel7
 
 # This image provides an Apache+PHP environment for running PHP
 # applications.
@@ -20,13 +20,13 @@ LABEL BZComponent="openshift-sti-php-docker" \
       Release="1" \
       Architecture="x86_64"
 
-# Install Apache httpd and PHP
-RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \
+# Install subscription-manager, Apache httpd and PHP
+RUN yum install -y subscription-manager && \
+    yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
     INSTALL_PKGS="httpd24 php55 php55-php php55-php-mysqlnd php55-php-pgsql php55-php-bcmath php55-php-devel \
                   php55-php-fpm php55-php-gd php55-php-intl php55-php-ldap php55-php-mbstring php55-php-pdo \
-                  php55-php-pecl-memcache php55-php-process php55-php-soap php55-php-opcache php55-php-xml \
-                  php55-php-pecl-imagick php55-php-pecl-xdebug" && \
+                  php55-php-pecl-memcache php55-php-process php55-php-soap php55-php-opcache php55-php-xml" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y

--- a/5.6/Dockerfile.rhel7
+++ b/5.6/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-FROM openshift/base-rhel7
+FROM registry.access.redhat.com/rhscl/s2i-base-rhel7
 
 # This image provides an Apache+PHP environment for running PHP
 # applications.
@@ -20,8 +20,9 @@ LABEL Name="rhscl/php-56-rhel7" \
       Release="3" \
       Architecture="x86_64"
 
-# Install Apache httpd and PHP
-RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \
+# Install subscription-manager, Apache httpd and PHP
+RUN yum install -y subscription-manager && \
+    yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
     INSTALL_PKGS="rh-php56 rh-php56-php rh-php56-php-mysqlnd rh-php56-php-pgsql rh-php56-php-bcmath \
                   rh-php56-php-gd rh-php56-php-intl rh-php56-php-ldap rh-php56-php-mbstring rh-php56-php-pdo \


### PR DESCRIPTION
I had to make the following changes to get a successful s2i build on rhel7.2:
 
 1) Changed FROM to use registry.access.redhat.com/rhscl/s2i-base-rhel7
 2) Installed subscription-manager 
 3) Removed php55-php-pecl-imagick php55-php-pecl-xdebug packages since I could not find them within RHEL7 (php55 only).