### PR TITLE
Add COMPOSER_MIRROR env var to allow Composer/Packagist mirror for PHP images

### DIFF
--- a/5.5/README.md
+++ b/5.5/README.md
@@ -141,6 +141,11 @@ yourself:
   * Default: 256 (this is automatically tuned by setting Cgroup limits for the container using this formula:
     `TOTAL_MEMORY / 15MB`. The 15MB is average size of a single httpd process.
 
+You can use a custom composer repository mirror URL to download packages instead of the default 'packagist.org':
+
+* **COMPOSER_MIRROR**
+  * Adds a custom composer repository mirror URL to composer configuration Note: This only affects packages listed in composer.json.
+
 Source repository layout
 ------------------------
 

--- a/5.5/s2i/bin/assemble
+++ b/5.5/s2i/bin/assemble
@@ -11,6 +11,11 @@ if [ -f composer.json ]; then
   # Install Composer
   php -r "readfile('https://getcomposer.org/installer');" | php
 
+  # Change the repo mirror if provided
+  if [ -n "$COMPOSER_MIRROR" ]; then
+    ./composer.phar config -g repositories.packagist composer $COMPOSER_MIRROR
+  fi
+
   # Install App dependencies using Composer
   ./composer.phar install --no-interaction --no-ansi --optimize-autoloader
 

--- a/5.6/README.md
+++ b/5.6/README.md
@@ -141,6 +141,11 @@ yourself:
   * Default: 256 (this is automatically tuned by setting Cgroup limits for the container using this formula:
     `TOTAL_MEMORY / 15MB`. The 15MB is average size of a single httpd process.
 
+  You can use a custom composer repository mirror URL to download packages instead of the default 'packagist.org':
+
+    * **COMPOSER_MIRROR**
+      * Adds a custom composer repository mirror URL to composer configuration. Note: This only affects packages listed in composer.json.
+
 Source repository layout
 ------------------------
 

--- a/5.6/s2i/bin/assemble
+++ b/5.6/s2i/bin/assemble
@@ -11,6 +11,11 @@ if [ -f composer.json ]; then
   # Install Composer
   php -r "readfile('https://getcomposer.org/installer');" | php
 
+  # Change the repo mirror if provided
+  if [ -n "$COMPOSER_MIRROR" ]; then
+    ./composer.phar config -g repositories.packagist composer $COMPOSER_MIRROR
+  fi
+
   # Install App dependencies using Composer
   ./composer.phar install --no-interaction --no-ansi --optimize-autoloader
 


### PR DESCRIPTION
The new COMPOSER_MIRROR env var is added to PHP images to allow custom
Composer/Packagist mirror to be used during build process.

Signed-off-by: Vu Dinh <vdinh@redhat.com>