### PR TITLE
Use mv instead cp to save space

### DIFF
--- a/5.5/s2i/bin/assemble
+++ b/5.5/s2i/bin/assemble
@@ -2,8 +2,9 @@
 
 set -e
 
+shopt -s dotglob
 echo "---> Installing application source..."
-cp -Rf /tmp/src/. ./
+mv /tmp/src/* ./
 
 if [ -f composer.json ]; then
   echo "Found 'composer.json', installing dependencies using composer.phar... "

--- a/5.6/s2i/bin/assemble
+++ b/5.6/s2i/bin/assemble
@@ -2,8 +2,9 @@
 
 set -e
 
+shopt -s dotglob
 echo "---> Installing application source..."
-cp -Rf /tmp/src/. ./
+mv /tmp/src/* ./
 
 if [ -f composer.json ]; then
   echo "Found 'composer.json', installing dependencies using composer.phar... "


### PR DESCRIPTION
@bparees this have been used on 5.5 and 5.6 tags without issues, PTAL.

fixes https://github.com/sclorg/s2i-php-container/issues/106