### PR TITLE
set PHP date.timezone at assebly if not set

### DIFF
--- a/5.5/s2i/bin/assemble
+++ b/5.5/s2i/bin/assemble
@@ -9,6 +9,12 @@ mv /tmp/src/* ./
 if [ -f composer.json ]; then
   echo "Found 'composer.json', installing dependencies using composer.phar... "
 
+  PHP_CONFIG=/opt/rh/php55/root/etc/php.ini
+  if [ "$(grep '^data\.timezone' $PHP_CONFIG ; echo $?)" -eq "1" ] ; then
+    # composer et al need timezone defined, php.ini will be generated at runtime
+    echo "date.timezone = GMT" >> $PHP_CONFIG
+  fi
+
   # Install Composer
   php -r "readfile('https://getcomposer.org/installer');" | php
 

--- a/5.6/s2i/bin/assemble
+++ b/5.6/s2i/bin/assemble
@@ -9,6 +9,12 @@ mv /tmp/src/* ./
 if [ -f composer.json ]; then
   echo "Found 'composer.json', installing dependencies using composer.phar... "
 
+  PHP_CONFIG=/etc/opt/rh/rh-php56/php.ini
+  if [ "$(grep '^data\.timezone' $PHP_CONFIG ; echo $?)" -eq "1" ] ; then
+    # composer et al need timezone defined, php.ini will be generated at runtime
+    echo "date.timezone = GMT" >> $PHP_CONFIG
+  fi
+
   # Install Composer
   php -r "readfile('https://getcomposer.org/installer');" | php
 


### PR DESCRIPTION
Similar to #87 I had the problem that composer needs the timezone to be set at assemble-time while we set it at run-time.

This patch sets the timezone if composer needs to run and the user has not set it separately