### PR TITLE
Set default opcache.memory_consumption to 128MB

### DIFF
--- a/5.6/README.md
+++ b/5.6/README.md
@@ -116,7 +116,7 @@ The following environment variables set their equivalent property value in the p
 The following environment variables set their equivalent property value in the opcache.ini file:
 * **OPCACHE_MEMORY_CONSUMPTION**
   * The OPcache shared memory storage size
-  * Default: 16M
+  * Default: 128M
 * **OPCACHE_REVALIDATE_FREQ**
   * How often to check script timestamps for updates, in seconds. 0 will result in OPcache checking for updates on every request.
   * Default: 2

--- a/5.6/README.md
+++ b/5.6/README.md
@@ -115,8 +115,8 @@ The following environment variables set their equivalent property value in the p
 
 The following environment variables set their equivalent property value in the opcache.ini file:
 * **OPCACHE_MEMORY_CONSUMPTION**
-  * The OPcache shared memory storage size
-  * Default: 128M
+  * The OPcache shared memory storage size in megabytes
+  * Default: 128
 * **OPCACHE_REVALIDATE_FREQ**
   * How often to check script timestamps for updates, in seconds. 0 will result in OPcache checking for updates on every request.
   * Default: 2

--- a/5.6/s2i/bin/run
+++ b/5.6/s2i/bin/run
@@ -14,7 +14,7 @@ export INCLUDE_PATH=${INCLUDE_PATH:-.:/opt/app-root/src:/opt/rh/rh-php56/root/us
 export SESSION_PATH=${SESSION_PATH:-/tmp/sessions}
 export SHORT_OPEN_TAG=${SHORT_OPEN_TAG:-OFF}
 # TODO should be dynamically calculated based on container memory limit/16
-export OPCACHE_MEMORY_CONSUMPTION=${OPCACHE_MEMORY_CONSUMPTION:-16}
+export OPCACHE_MEMORY_CONSUMPTION=${OPCACHE_MEMORY_CONSUMPTION:-128}
 
 export OPCACHE_REVALIDATE_FREQ=${OPCACHE_REVALIDATE_FREQ:-2}
 

--- a/7.0/README.md
+++ b/7.0/README.md
@@ -116,7 +116,7 @@ The following environment variables set their equivalent property value in the p
 The following environment variables set their equivalent property value in the opcache.ini file:
 * **OPCACHE_MEMORY_CONSUMPTION**
   * The OPcache shared memory storage size
-  * Default: 16M
+  * Default: 128M
 * **OPCACHE_REVALIDATE_FREQ**
   * How often to check script timestamps for updates, in seconds. 0 will result in OPcache checking for updates on every request.
   * Default: 2

--- a/7.0/README.md
+++ b/7.0/README.md
@@ -115,8 +115,8 @@ The following environment variables set their equivalent property value in the p
 
 The following environment variables set their equivalent property value in the opcache.ini file:
 * **OPCACHE_MEMORY_CONSUMPTION**
-  * The OPcache shared memory storage size
-  * Default: 128M
+  * The OPcache shared memory storage size in megabytes
+  * Default: 128
 * **OPCACHE_REVALIDATE_FREQ**
   * How often to check script timestamps for updates, in seconds. 0 will result in OPcache checking for updates on every request.
   * Default: 2

--- a/7.0/s2i/bin/run
+++ b/7.0/s2i/bin/run
@@ -14,7 +14,7 @@ export INCLUDE_PATH=${INCLUDE_PATH:-.:/opt/app-root/src:/opt/rh/rh-php70/root/us
 export SESSION_PATH=${SESSION_PATH:-/tmp/sessions}
 export SHORT_OPEN_TAG=${SHORT_OPEN_TAG:-OFF}
 # TODO should be dynamically calculated based on container memory limit/16
-export OPCACHE_MEMORY_CONSUMPTION=${OPCACHE_MEMORY_CONSUMPTION:-16}
+export OPCACHE_MEMORY_CONSUMPTION=${OPCACHE_MEMORY_CONSUMPTION:-128}
 
 export OPCACHE_REVALIDATE_FREQ=${OPCACHE_REVALIDATE_FREQ:-2}
 


### PR DESCRIPTION
Resolve #152 by setting default for Opcache Memory Consumption to 128MB on PHP5.6 and PHP7.0