### PR TITLE
Update Dockerfiles

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -3,17 +3,31 @@ FROM centos/s2i-base-centos7
 # This image provides an Apache+PHP environment for running PHP
 # applications.
 
-MAINTAINER SoftwareCollections.org <sclorg@redhat.com>
-
 EXPOSE 8080
 
 ENV PHP_VERSION=5.6 \
     PATH=$PATH:/opt/rh/rh-php56/root/usr/bin
 
-LABEL io.k8s.description="Platform for building and running PHP 5.6 applications" \
+ENV SUMMARY="Platform for building and running PHP $PHP_VERSION applications" \
+    DESCRIPTION="PHP $PHP_VERSION available as docker container is a base platform for \
+building and running various PHP $PHP_VERSION applications and frameworks. \
+PHP is an HTML-embedded scripting language. PHP attempts to make it easy for developers \
+to write dynamically generated web pages. PHP also offers built-in database integration \
+for several commercial and non-commercial database management systems, so writing \
+a database-enabled webpage with PHP is fairly simple. The most common use of PHP coding \
+is probably as a replacement for CGI scripts."
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$SUMMARY" \
       io.k8s.display-name="Apache 2.4 with PHP 5.6" \
       io.openshift.expose-services="8080:http" \
-      io.openshift.tags="builder,php,php56,rh-php56"
+      io.openshift.tags="builder,php,php56,rh-php56" \
+      name="centos/php-56-centos7" \
+      com.redhat.component="rh-php56-docker" \
+      version="5.6" \
+      release="1" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 # Install Apache httpd and PHP
 RUN yum install -y centos-release-scl && \

--- a/5.6/Dockerfile.rhel7
+++ b/5.6/Dockerfile.rhel7
@@ -8,17 +8,25 @@ EXPOSE 8080
 ENV PHP_VERSION=5.6 \
     PATH=$PATH:/opt/rh/rh-php56/root/usr/bin
 
-LABEL io.k8s.description="Platform for building and running PHP 5.6 applications" \
+ENV SUMMARY="Platform for building and running PHP $PHP_VERSION applications" \
+    DESCRIPTION="PHP $PHP_VERSION available as docker container is a base platform for \
+building and running various PHP $PHP_VERSION applications and frameworks. \
+PHP is an HTML-embedded scripting language. PHP attempts to make it easy for developers \
+to write dynamically generated web pages. PHP also offers built-in database integration \
+for several commercial and non-commercial database management systems, so writing \
+a database-enabled webpage with PHP is fairly simple. The most common use of PHP coding \
+is probably as a replacement for CGI scripts."
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$SUMMARY" \
       io.k8s.display-name="Apache 2.4 with PHP 5.6" \
       io.openshift.expose-services="8080:http" \
-      io.openshift.tags="builder,php,php56,rh-php56"
-
-# Labels consumed by Red Hat build service
-LABEL name="rhscl/php-56-rhel7" \
+      io.openshift.tags="builder,php,php56,rh-php56" \
+      name="rhscl/php-56-rhel7" \
       com.redhat.component="rh-php56-docker" \
       version="5.6" \
-      release="3" \
-      architecture="x86_64"
+      release="3"
 
 # Install Apache httpd and PHP
 # To use subscription inside container yum command has to be run first (before yum-config-manager)

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -1,7 +1,5 @@
 FROM centos/s2i-base-centos7
 
-MAINTAINER SoftwareCollections.org <sclorg@redhat.com>
-
 # This image provides an Apache+PHP environment for running PHP
 # applications.
 
@@ -10,10 +8,26 @@ EXPOSE 8080
 ENV PHP_VERSION=7.0 \
     PATH=$PATH:/opt/rh/rh-php70/root/usr/bin
 
-LABEL io.k8s.description="Platform for building and running PHP 7.0 applications" \
+ENV SUMMARY="Platform for building and running PHP $PHP_VERSION applications" \
+    DESCRIPTION="PHP $PHP_VERSION available as docker container is a base platform for \
+building and running various PHP $PHP_VERSION applications and frameworks. \
+PHP is an HTML-embedded scripting language. PHP attempts to make it easy for developers \
+to write dynamically generated web pages. PHP also offers built-in database integration \
+for several commercial and non-commercial database management systems, so writing \
+a database-enabled webpage with PHP is fairly simple. The most common use of PHP coding \
+is probably as a replacement for CGI scripts."
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$SUMMARY" \
       io.k8s.display-name="Apache 2.4 with PHP 7.0" \
       io.openshift.expose-services="8080:http" \
-      io.openshift.tags="builder,php,php70,rh-php70"
+      io.openshift.tags="builder,php,php70,rh-php70" \
+      name="centos/php-70-centos7" \
+      com.redhat.component="rh-php70-docker" \
+      version="7.0" \
+      release="1" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 # Install Apache httpd and PHP
 RUN yum install -y centos-release-scl && \

--- a/7.0/Dockerfile.rhel7
+++ b/7.0/Dockerfile.rhel7
@@ -8,17 +8,25 @@ EXPOSE 8080
 ENV PHP_VERSION=7.0 \
     PATH=$PATH:/opt/rh/rh-php70/root/usr/bin
 
-LABEL io.k8s.description="Platform for building and running PHP 7.0 applications" \
+ENV SUMMARY="Platform for building and running PHP $PHP_VERSION applications" \
+    DESCRIPTION="PHP $PHP_VERSION available as docker container is a base platform for \
+building and running various PHP $PHP_VERSION applications and frameworks. \
+PHP is an HTML-embedded scripting language. PHP attempts to make it easy for developers \
+to write dynamically generated web pages. PHP also offers built-in database integration \
+for several commercial and non-commercial database management systems, so writing \
+a database-enabled webpage with PHP is fairly simple. The most common use of PHP coding \
+is probably as a replacement for CGI scripts."
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$SUMMARY" \
       io.k8s.display-name="Apache 2.4 with PHP 7.0" \
       io.openshift.expose-services="8080:http" \
-      io.openshift.tags="builder,php,php70,rh-php70"
-
-# Labels consumed by Red Hat build service
-LABEL name="rhscl/php-70-rhel7" \
+      io.openshift.tags="builder,php,php70,rh-php70" \
+      name="rhscl/php-70-rhel7" \
       com.redhat.component="rh-php70-docker" \
       version="7.0" \
-      release="5.0" \
-      architecture="x86_64"
+      release="5.0"
 
 # Install Apache httpd and PHP
 # To use subscription inside container yum command has to be run first (before yum-config-manager)


### PR DESCRIPTION
Provide same labels for all base image variants (CentOS, RHEL, Fedora)
 - follow recomended labels from Project Atomic Container best practices
 - add summary and description labels (Fedora requirements) - use ENV for simple using of same value in more descriptive labels
 - remove architecture label for RHEL based images (this label is set in RHEL image - no need to define it again)
 - use label 'maintainer' (MAINTAINER instruction is deprecated)
                                           
(don't use separate instruction for each label)

@hhorak @praiskup @pkubatrh Please take a look and merge.