### PR TITLE
Enable rh-nodejs6, so users can use npm for installing JavaScript stuff

### DIFF
--- a/5.6/root/opt/app-root/etc/scl_enable
+++ b/5.6/root/opt/app-root/etc/scl_enable
@@ -3,4 +3,4 @@
 #
 # This will make scl collection binaries work out of box.
 unset BASH_ENV PROMPT_COMMAND ENV
-source scl_source enable rh-php56 httpd24
+source scl_source enable rh-php56 httpd24 rh-nodejs6

--- a/7.0/root/opt/app-root/etc/scl_enable
+++ b/7.0/root/opt/app-root/etc/scl_enable
@@ -3,4 +3,4 @@
 #
 # This will make scl collection binaries work out of box.
 unset BASH_ENV PROMPT_COMMAND ENV
-source scl_source enable rh-php70 httpd24
+source scl_source enable rh-php70 httpd24 rh-nodejs6


### PR DESCRIPTION
Similarly to https://github.com/sclorg/s2i-python-container/pull/209