### PR TITLE
Ability to set custom Composer download URL

### DIFF
--- a/5.6/README.md
+++ b/5.6/README.md
@@ -113,6 +113,8 @@ yourself:
 
     * **COMPOSER_MIRROR**
       * Adds a custom composer repository mirror URL to composer configuration. Note: This only affects packages listed in composer.json.
+    * **COMPOSER_INSTALLER**
+      * Overrides the default URL for downloading Composer of https://getcomposer.org/installer. Useful in disconnected environments.
 
 Source repository layout
 ------------------------

--- a/5.6/s2i/bin/assemble
+++ b/5.6/s2i/bin/assemble
@@ -13,8 +13,13 @@ if [ -f composer.json ]; then
   TEMPFILE=$(mktemp)
   RETRIES=6
   for ((i=0; i<$RETRIES; i++)); do
-    echo "Downloading https://getcomposer.org/installer, attempt $((i+1))/$RETRIES"
-    curl -o $TEMPFILE https://getcomposer.org/installer && break
+
+    if [ -n "$COMPOSER_INSTALLER" ]; then
+      export COMPOSER_INSTALLER="https://getcomposer.org/installer"
+    fi
+
+    echo "Downloading $COMPOSER_INSTALLER, attempt $((i+1))/$RETRIES"
+    curl -o $TEMPFILE $COMPOSER_INSTALLER && break
     sleep 10
   done
   if [[ $i == $RETRIES ]]; then

--- a/5.6/s2i/bin/assemble
+++ b/5.6/s2i/bin/assemble
@@ -14,7 +14,7 @@ if [ -f composer.json ]; then
   RETRIES=6
   for ((i=0; i<$RETRIES; i++)); do
 
-    if [ -n "$COMPOSER_INSTALLER" ]; then
+    if [ -z "$COMPOSER_INSTALLER" ]; then
       export COMPOSER_INSTALLER="https://getcomposer.org/installer"
     fi
 

--- a/7.0/README.md
+++ b/7.0/README.md
@@ -113,6 +113,8 @@ yourself:
 
     * **COMPOSER_MIRROR**
       * Adds a custom composer repository mirror URL to composer configuration. Note: This only affects packages listed in composer.json.
+    * **COMPOSER_INSTALLER**
+      * Overrides the default URL for downloading Composer of https://getcomposer.org/installer. Useful in disconnected environments.
 
 Source repository layout
 ------------------------

--- a/7.0/s2i/bin/assemble
+++ b/7.0/s2i/bin/assemble
@@ -13,8 +13,13 @@ if [ -f composer.json ]; then
   TEMPFILE=$(mktemp)
   RETRIES=6
   for ((i=0; i<$RETRIES; i++)); do
-    echo "Downloading https://getcomposer.org/installer, attempt $((i+1))/$RETRIES"
-    curl -o $TEMPFILE https://getcomposer.org/installer && break
+
+    if [ -n "$COMPOSER_INSTALLER" ]; then
+      export COMPOSER_INSTALLER="https://getcomposer.org/installer"
+    fi
+
+    echo "Downloading $COMPOSER_INSTALLER, attempt $((i+1))/$RETRIES"
+    curl -o $TEMPFILE $COMPOSER_INSTALLER && break
     sleep 10
   done
   if [[ $i == $RETRIES ]]; then

--- a/7.0/s2i/bin/assemble
+++ b/7.0/s2i/bin/assemble
@@ -14,7 +14,7 @@ if [ -f composer.json ]; then
   RETRIES=6
   for ((i=0; i<$RETRIES; i++)); do
 
-    if [ -n "$COMPOSER_INSTALLER" ]; then
+    if [ -z "$COMPOSER_INSTALLER" ]; then
       export COMPOSER_INSTALLER="https://getcomposer.org/installer"
     fi
 

--- a/7.1/README.md
+++ b/7.1/README.md
@@ -109,10 +109,14 @@ yourself:
   * Default: 256 (this is automatically tuned by setting Cgroup limits for the container using this formula:
     `TOTAL_MEMORY / 15MB`. The 15MB is average size of a single httpd process.
 
+    * **COMPOSER_INSTALLER**
+      * Overrides the default URL for downloading Composer from https://getcomposer.org/installer. Useful in disconnected environments.
+
   You can use a custom composer repository mirror URL to download packages instead of the default 'packagist.org':
 
     * **COMPOSER_MIRROR**
       * Adds a custom composer repository mirror URL to composer configuration. Note: This only affects packages listed in composer.json.
+
 
 Source repository layout
 ------------------------

--- a/7.1/README.md
+++ b/7.1/README.md
@@ -109,13 +109,12 @@ yourself:
   * Default: 256 (this is automatically tuned by setting Cgroup limits for the container using this formula:
     `TOTAL_MEMORY / 15MB`. The 15MB is average size of a single httpd process.
 
-    * **COMPOSER_INSTALLER**
-      * Overrides the default URL for downloading Composer from https://getcomposer.org/installer. Useful in disconnected environments.
-
   You can use a custom composer repository mirror URL to download packages instead of the default 'packagist.org':
 
     * **COMPOSER_MIRROR**
       * Adds a custom composer repository mirror URL to composer configuration. Note: This only affects packages listed in composer.json.
+    * **COMPOSER_INSTALLER**
+      * Overrides the default URL for downloading Composer of https://getcomposer.org/installer. Useful in disconnected environments.
 
 
 Source repository layout

--- a/7.1/s2i/bin/assemble
+++ b/7.1/s2i/bin/assemble
@@ -15,7 +15,7 @@ if [ -f composer.json ]; then
   for ((i=0; i<$RETRIES; i++)); do
 
     if [ -n "$COMPOSER_INSTALLER" ]; then
-      $COMPOSER_INSTALLER="https://getcomposer.org/installer"
+      export COMPOSER_INSTALLER="https://getcomposer.org/installer"
     fi
 
     echo "Downloading $COMPOSER_INSTALLER, attempt $((i+1))/$RETRIES"

--- a/7.1/s2i/bin/assemble
+++ b/7.1/s2i/bin/assemble
@@ -13,8 +13,13 @@ if [ -f composer.json ]; then
   TEMPFILE=$(mktemp)
   RETRIES=6
   for ((i=0; i<$RETRIES; i++)); do
-    echo "Downloading https://getcomposer.org/installer, attempt $((i+1))/$RETRIES"
-    curl -o $TEMPFILE https://getcomposer.org/installer && break
+
+    if [ -n "$COMPOSER_INSTALLER" ]; then
+      $COMPOSER_INSTALLER="https://getcomposer.org/installer"
+    fi
+
+    echo "Downloading $COMPOSER_INSTALLER, attempt $((i+1))/$RETRIES"
+    curl -o $TEMPFILE $COMPOSER_INSTALLER && break
     sleep 10
   done
   if [[ $i == $RETRIES ]]; then

--- a/7.1/s2i/bin/assemble
+++ b/7.1/s2i/bin/assemble
@@ -34,7 +34,7 @@ if [ -f composer.json ]; then
   fi
 
   # Change the repo mirror if provided
-  if [ -n "$COMPOSER_MIRROR" ]; then
+  if [ -z "$COMPOSER_MIRROR" ]; then
     ./composer.phar config -g repositories.packagist composer $COMPOSER_MIRROR
   fi
 

--- a/7.1/s2i/bin/assemble
+++ b/7.1/s2i/bin/assemble
@@ -14,7 +14,7 @@ if [ -f composer.json ]; then
   RETRIES=6
   for ((i=0; i<$RETRIES; i++)); do
 
-    if [ -n "$COMPOSER_INSTALLER" ]; then
+    if [ -z "$COMPOSER_INSTALLER" ]; then
       export COMPOSER_INSTALLER="https://getcomposer.org/installer"
     fi
 
@@ -34,7 +34,7 @@ if [ -f composer.json ]; then
   fi
 
   # Change the repo mirror if provided
-  if [ -z "$COMPOSER_MIRROR" ]; then
+  if [ -n "$COMPOSER_MIRROR" ]; then
     ./composer.phar config -g repositories.packagist composer $COMPOSER_MIRROR
   fi
 


### PR DESCRIPTION
In disconnected environments it is necessary to allow the developer to specify the Composer installer URL. Work done to PHP 7.1 however I plan to backport to the earlier versions.