### PR TITLE
Fix permissions for /tmp/sessions

### DIFF
--- a/5.6/root/usr/libexec/container-setup
+++ b/5.6/root/usr/libexec/container-setup
@@ -38,6 +38,7 @@ chmod -R a+rwx ${APP_ROOT}/etc
 chmod -R a+rwx ${HTTPD_VAR_RUN}
 chown -R 1001:0 ${APP_ROOT}
 mkdir /tmp/sessions
+chmod -R a+rwx /tmp/sessions
 chown -R 1001:0 /tmp/sessions
 chown -R 1001:0 ${HTTPD_DATA_PATH}
 chmod -R a+rwx ${PHP_SYSCONF_PATH}

--- a/7.0/root/usr/libexec/container-setup
+++ b/7.0/root/usr/libexec/container-setup
@@ -38,6 +38,7 @@ chmod -R a+rwx ${APP_ROOT}/etc
 chmod -R a+rwx ${HTTPD_VAR_RUN}
 chown -R 1001:0 ${APP_ROOT}
 mkdir /tmp/sessions
+chmod -R a+rwx /tmp/sessions
 chown -R 1001:0 /tmp/sessions
 chown -R 1001:0 ${HTTPD_DATA_PATH}
 chmod -R a+rwx ${PHP_SYSCONF_PATH}

--- a/7.1/root/usr/libexec/container-setup
+++ b/7.1/root/usr/libexec/container-setup
@@ -38,6 +38,7 @@ chmod -R a+rwx ${APP_ROOT}/etc
 chmod -R a+rwx ${HTTPD_VAR_RUN}
 chown -R 1001:0 ${APP_ROOT}
 mkdir /tmp/sessions
+chmod -R a+rwx /tmp/sessions
 chown -R 1001:0 /tmp/sessions
 chown -R 1001:0 ${HTTPD_DATA_PATH}
 chmod -R a+rwx ${PHP_SYSCONF_PATH}


### PR DESCRIPTION
Try to fix issue #189.
`chmod -R a+rwx /tmp/sessions` was run before the code moved to /usr/libexec/container-setup.