### PR TITLE
OKD rebranding and sclorg move

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Users can choose between RHEL and CentOS based builder images.
 The resulting image can be run using [Docker](http://docker.io).
 
 For more information about using these images with OpenShift, please see the
-official [OpenShift Documentation](https://docs.openshift.org/latest/using_images/s2i_images/php.html).
+official [OpenShift Documentation](https://docs.okd.io/latest/using_images/s2i_images/php.html).
 
 For more information about contributing, see
 [the Contribution Guidelines](https://github.com/sclorg/welcome/blob/master/contribution.md).

--- a/imagestreams/php-centos7.json
+++ b/imagestreams/php-centos7.json
@@ -18,7 +18,7 @@
           "iconClass": "icon-php",
           "tags": "builder,php",
           "supports":"php",
-          "sampleRepo": "https://github.com/openshift/cakephp-ex.git"
+          "sampleRepo": "https://github.com/sclorg/cakephp-ex.git"
         },
         "from": {
           "kind": "ImageStreamTag",
@@ -38,7 +38,7 @@
           "tags": "hidden,builder,php",
           "supports":"php:5.5,php",
           "version": "5.5",
-          "sampleRepo": "https://github.com/openshift/cakephp-ex.git"
+          "sampleRepo": "https://github.com/sclorg/cakephp-ex.git"
         },
         "from": {
           "kind": "DockerImage",
@@ -58,7 +58,7 @@
           "tags": "hidden,builder,php",
           "supports":"php:5.6,php",
           "version": "5.6",
-          "sampleRepo": "https://github.com/openshift/cakephp-ex.git"
+          "sampleRepo": "https://github.com/sclorg/cakephp-ex.git"
         },
         "from": {
           "kind": "DockerImage",
@@ -78,7 +78,7 @@
           "tags": "builder,php",
           "supports":"php:7.0,php",
           "version": "7.0",
-          "sampleRepo": "https://github.com/openshift/cakephp-ex.git"
+          "sampleRepo": "https://github.com/sclorg/cakephp-ex.git"
         },
         "from": {
           "kind": "DockerImage",
@@ -98,7 +98,7 @@
           "tags": "builder,php",
           "supports":"php:7.1,php",
           "version": "7.1",
-          "sampleRepo": "https://github.com/openshift/cakephp-ex.git"
+          "sampleRepo": "https://github.com/sclorg/cakephp-ex.git"
         },
         "from": {
           "kind": "DockerImage",

--- a/imagestreams/php-rhel7-ppc64le.json
+++ b/imagestreams/php-rhel7-ppc64le.json
@@ -18,7 +18,7 @@
           "iconClass": "icon-php",
           "tags": "builder,php,ppc64le",
           "supports":"php",
-          "sampleRepo": "https://github.com/openshift/cakephp-ex.git"
+          "sampleRepo": "https://github.com/sclorg/cakephp-ex.git"
         },
         "from": {
           "kind": "ImageStreamTag",
@@ -38,7 +38,7 @@
           "tags": "builder,php,ppc64le",
           "supports":"php:7.1,php",
           "version": "7.1",
-          "sampleRepo": "https://github.com/openshift/cakephp-ex.git"
+          "sampleRepo": "https://github.com/sclorg/cakephp-ex.git"
         },
         "from": {
           "kind": "DockerImage",

--- a/imagestreams/php-rhel7.json
+++ b/imagestreams/php-rhel7.json
@@ -18,7 +18,7 @@
           "iconClass": "icon-php",
           "tags": "builder,php",
           "supports":"php",
-          "sampleRepo": "https://github.com/openshift/cakephp-ex.git"
+          "sampleRepo": "https://github.com/sclorg/cakephp-ex.git"
         },
         "from": {
           "kind": "ImageStreamTag",
@@ -38,7 +38,7 @@
           "tags": "hidden,builder,php",
           "supports":"php:5.5,php",
           "version": "5.5",
-          "sampleRepo": "https://github.com/openshift/cakephp-ex.git"
+          "sampleRepo": "https://github.com/sclorg/cakephp-ex.git"
         },
         "from": {
           "kind": "DockerImage",
@@ -58,7 +58,7 @@
           "tags": "hidden,builder,php",
           "supports":"php:5.6,php",
           "version": "5.6",
-          "sampleRepo": "https://github.com/openshift/cakephp-ex.git"
+          "sampleRepo": "https://github.com/sclorg/cakephp-ex.git"
         },
         "from": {
           "kind": "DockerImage",
@@ -78,7 +78,7 @@
           "tags": "builder,php",
           "supports":"php:7.0,php",
           "version": "7.0",
-          "sampleRepo": "https://github.com/openshift/cakephp-ex.git"
+          "sampleRepo": "https://github.com/sclorg/cakephp-ex.git"
         },
         "from": {
           "kind": "DockerImage",
@@ -98,7 +98,7 @@
           "tags": "builder,php",
           "supports":"php:7.1,php",
           "version": "7.1",
-          "sampleRepo": "https://github.com/openshift/cakephp-ex.git"
+          "sampleRepo": "https://github.com/sclorg/cakephp-ex.git"
         },
         "from": {
           "kind": "DockerImage",


### PR DESCRIPTION
docs.openshift.org to docs.okd.io
github.com/openshift/cakephp-ex to github.com/sclorg/cakephp-ex