### PR TITLE
Fix Fedora based image - switch back to 'prefork'

### DIFF
--- a/7.1/Dockerfile.fedora
+++ b/7.1/Dockerfile.fedora
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/f26/s2i-base:latest
+FROM registry.fedoraproject.org/f27/s2i-base:latest
 
 # This image provides an Apache+PHP environment for running PHP
 # applications.
@@ -32,7 +32,6 @@ LABEL summary="$SUMMARY" \
       name="$FGC/$NAME" \
       com.redhat.component="$NAME" \
       version="$VERSION" \
-      release="$RELEASE" \
       usage="s2i build https://github.com/sclorg/s2i-php-container.git --context-dir=/7.1/test/test-app $FGC/$NAME sample-server" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
@@ -40,7 +39,7 @@ LABEL summary="$SUMMARY" \
 RUN INSTALL_PKGS="php php-mysqlnd php-bcmath \
                   php-gd php-intl php-ldap php-mbstring php-pdo \
                   php-process php-soap php-opcache php-xml \
-                  php-gmp php-pecl-apcu mod_ssl" && \
+                  php-gmp php-pecl-apcu mod_ssl hostname" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS --nogpgcheck && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y
@@ -65,7 +64,22 @@ COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 COPY ./root/ /
 
 # Reset permissions of filesystem to default values
-RUN /usr/libexec/container-setup && rpm-file-permissions
+# Generate SSL certs and reset permissions of filesystem to default values
+RUN /usr/libexec/httpd-ssl-gencerts && \
+    /usr/libexec/container-setup && rpm-file-permissions
+
+# Fedora uses by default 'event' MPM module
+# switch to 'prefork' to provide same user experience as with RHEL image
+# Code taken from 'config_mpm()' function in sclorg/httpd-container repo
+ENV HTTPD_MPM=prefork \
+    HTTPD_MAIN_CONF_MODULES_D_PATH=/etc/httpd/conf.modules.d
+
+RUN if [ -v HTTPD_MPM -a -f ${HTTPD_MAIN_CONF_MODULES_D_PATH}/00-mpm.conf ]; then \
+    mpmconf=${HTTPD_MAIN_CONF_MODULES_D_PATH}/00-mpm.conf; \
+    sed -i -e 's,^LoadModule,#LoadModule,' ${mpmconf}; \
+    sed -i -e "/LoadModule mpm_${HTTPD_MPM}/s,^#LoadModule,LoadModule," ${mpmconf}; \
+    echo "---> Set MPM to ${HTTPD_MPM} in ${mpmconf}"; \
+  fi
 
 USER 1001
 

--- a/test/run-openshift
+++ b/test/run-openshift
@@ -65,9 +65,11 @@ fi
 # test image update with s2i
 case "$OS" in
   rhel7) old_image=rhscl/php-${VERSION/./}-rhel7 ;;
+# Fedora image isn't in registry yet
+#  fedora) old_image=${IMAGE_NAME/localhost\//}
   *) old_image=centos/php-${VERSION/./}-centos7 ;;
 esac
-ct_os_test_image_update "$IMAGE_NAME" "${IMAGE_NAME/localhost\//}" "$istag" \
+ct_os_test_image_update "$IMAGE_NAME" "${old_image}" "$istag" \
                         'ct_test_response "http://<IP>:8080" "200" "Test PHP passed"' \
                         "$istag~https://github.com/sclorg/s2i-php-container.git" \
                         --context-dir="$VERSION/test/test-app"


### PR DESCRIPTION
Fedora uses by default 'event' MPM module, so switch to 'prefork'
to provide same user experience as with RHEL/CentOS image.

For more information see https://bugzilla.redhat.com/show_bug.cgi?id=1586332 .

@pkubatrh @notroj @remicollet @dustymabe Please review. Any ideas are welcomed!