### PR TITLE
Fix documentation for environment variables

### DIFF
--- a/7.0/README.md
+++ b/7.0/README.md
@@ -51,7 +51,7 @@ $ curl 127.0.0.1:8080
 Environment variables
 ---------------------
 
-To set these environment variables, you can place them as a key value pair into a `.sti/environment`
+To set these environment variables, you can place them as a key value pair into a `.s2i/environment`
 file inside your source code repository.
 
 The following environment variables set their equivalent property value in the php.ini file:

--- a/7.1/README.md
+++ b/7.1/README.md
@@ -51,7 +51,7 @@ $ curl 127.0.0.1:8080
 Environment variables
 ---------------------
 
-To set these environment variables, you can place them as a key value pair into a `.sti/environment`
+To set these environment variables, you can place them as a key value pair into a `.s2i/environment`
 file inside your source code repository.
 
 The following environment variables set their equivalent property value in the php.ini file:

--- a/7.2/README.md
+++ b/7.2/README.md
@@ -61,7 +61,7 @@ $ curl 127.0.0.1:8080
 Environment variables
 ---------------------
 
-To set these environment variables, you can place them as a key value pair into a `.sti/environment`
+To set these environment variables, you can place them as a key value pair into a `.s2i/environment`
 file inside your source code repository.
 
 The following environment variables set their equivalent property value in the php.ini file:


### PR DESCRIPTION
The environment variables in `.sti` are not injected.

Renaming `.sti` to `.s2i` fixes this problem. I guess that part of the documentation was forgotten when renaming.