### PR TITLE
Quotes prevent syntax failure at startup when using redis cluster

### DIFF
--- a/7.2/root/opt/app-root/etc/php.ini.template
+++ b/7.2/root/opt/app-root/etc/php.ini.template
@@ -1209,7 +1209,7 @@ session.save_handler = ${SESSION_HANDLER}
 ; RPM note : session directory must be owned by process owner
 ; for mod_php, see /etc/httpd/conf.d/php.conf
 ; for php-fpm, see /etc/php-fpm.d/*conf
-session.save_path = ${SESSION_PATH}
+session.save_path = "${SESSION_PATH}"
 
 ; Whether to use strict session mode.
 ; Strict session mode does not accept uninitialized session ID and regenerate


### PR DESCRIPTION
This pull request fixes problem when using more complex session save paths. They need quotes.