### PR TITLE
Fix permissions for all files given in s2i

### DIFF
--- a/7.0/s2i/bin/assemble
+++ b/7.0/s2i/bin/assemble
@@ -8,6 +8,10 @@ shopt -s dotglob
 echo "---> Installing application source..."
 mv /tmp/src/* ./
 
+# Fix source directory permissions
+fix-permissions ./
+fix-permissions ${HTTPD_CONFIGURATION_PATH}
+
 if [ -f composer.json ]; then
   echo "Found 'composer.json', installing dependencies using composer.phar... "
 

--- a/7.1/s2i/bin/assemble
+++ b/7.1/s2i/bin/assemble
@@ -8,6 +8,10 @@ shopt -s dotglob
 echo "---> Installing application source..."
 mv /tmp/src/* ./
 
+# Fix source directory permissions
+fix-permissions ./
+fix-permissions ${HTTPD_CONFIGURATION_PATH}
+
 if [ -f composer.json ]; then
   echo "Found 'composer.json', installing dependencies using composer.phar... "
 

--- a/7.2/s2i/bin/assemble
+++ b/7.2/s2i/bin/assemble
@@ -8,6 +8,10 @@ shopt -s dotglob
 echo "---> Installing application source..."
 mv /tmp/src/* ./
 
+# Fix source directory permissions
+fix-permissions ./
+fix-permissions ${HTTPD_CONFIGURATION_PATH}
+
 if [ -f composer.json ]; then
   echo "Found 'composer.json', installing dependencies using composer.phar... "
 


### PR DESCRIPTION
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>

Move fix-permissions right after `mv`.

Reference issue:
https://github.com/sclorg/container-common-scripts/issues/119