### PR TITLE
Use refactored functions and enable testing in remote OCP4

### DIFF
--- a/7.2/test/imagestreams
+++ b/7.2/test/imagestreams
@@ -1,0 +1,1 @@
+../../imagestreams/

--- a/7.3/test/imagestreams
+++ b/7.3/test/imagestreams
@@ -1,0 +1,1 @@
+../../imagestreams/

--- a/test/imagestreams
+++ b/test/imagestreams
@@ -1,0 +1,1 @@
+../imagestreams/

--- a/test/run-openshift-local-cluster
+++ b/test/run-openshift-local-cluster
@@ -10,6 +10,7 @@ THISDIR=$(dirname ${BASH_SOURCE[0]})
 
 source ${THISDIR}/test-lib.sh
 source ${THISDIR}/test-lib-openshift.sh
+source ${THISDIR}/test-lib-php.sh
 
 # change the branch to a different value if a new change in the example
 # app needs to be tested
@@ -17,9 +18,12 @@ BRANCH_TO_TEST=master
 
 set -eo nounset
 
-test -n "${IMAGE_NAME-}" || false 'make sure $IMAGE_NAME is defined'
-test -n "${VERSION-}" || false 'make sure $VERSION is defined'
-test -n "${OS-}" || false 'make sure $OS is defined'
+trap ct_os_cleanup EXIT SIGINT
+
+ct_os_check_compulsory_vars
+
+ct_os_enable_print_logs
+
 istag="php:$VERSION"
 
 function test_file_upload() {
@@ -75,3 +79,13 @@ else
 fi
 
 test_file_upload "$IMAGE_NAME"
+
+# Check the imagestream
+test_php_imagestream
+
+OS_TESTSUITE_RESULT=0
+
+ct_os_cluster_down
+
+# vim: set tabstop=2:shiftwidth=2:expandtab:
+

--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -24,7 +24,7 @@ export CT_SKIP_NEW_PROJECT=true
 export CT_SKIP_UPLOAD_IMAGE=true
 export CT_NAMESPACE=openshift
 
-test_php_integration "${IMAGE_NAME}" ${VERSION} php
+test_php_integration "${IMAGE_NAME}"
 
 # Check the imagestream
 test_php_imagestream

--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -24,7 +24,12 @@ export CT_SKIP_NEW_PROJECT=true
 export CT_SKIP_UPLOAD_IMAGE=true
 export CT_NAMESPACE=openshift
 
-test_php_integration php ${VERSION} "${IMAGE_NAME}"
+test_php_integration "${IMAGE_NAME}" ${VERSION} php
+
+# Check the imagestream
+test_php_imagestream
 
 OS_TESTSUITE_RESULT=0
+
+# vim: set tabstop=2:shiftwidth=2:expandtab:
 

--- a/test/test-lib-php.sh
+++ b/test/test-lib-php.sh
@@ -13,13 +13,10 @@ source ${THISDIR}/test-lib-openshift.sh
 
 function test_php_integration() {
   local image_name=$1
-  local version=$2
-  local import_image=$3
-  VERSION=$version ct_os_test_s2i_app "${image_name}" \
-                                      "https://github.com/sclorg/s2i-php-container.git" \
-                                      test/test-app \
-                                      "Test PHP passed" \
-                                      8080 http 200
+  ct_os_test_s2i_app "${image_name}" \
+                     "https://github.com/sclorg/s2i-php-container.git" \
+                     "test/test-app" \
+                     "Test PHP passed"
 }
 
 # Check the imagestream

--- a/test/test-lib-php.sh
+++ b/test/test-lib-php.sh
@@ -19,8 +19,20 @@ function test_php_integration() {
                                       "https://github.com/sclorg/s2i-php-container.git" \
                                       test/test-app \
                                       "Test PHP passed" \
-                                      8080 http 200 "" \
-                                      "${import_image}"
+                                      8080 http 200
+}
+
+# Check the imagestream
+function test_php_imagestream() {
+  case ${OS} in
+    rhel7|centos7) ;;
+    *) echo "Imagestream testing not supported for $OS environment." ; return 0 ;;
+  esac
+
+  ct_os_test_image_stream_s2i "${THISDIR}/imagestreams/php-${OS}.json" "${IMAGE_NAME}" \
+                              "https://github.com/sclorg/s2i-php-container.git" \
+                              test/test-app \
+                              "Test PHP passed"
 }
 
 # vim: set tabstop=2:shiftwidth=2:expandtab:


### PR DESCRIPTION
This PR combines more changes:

- add image stream test
- adopts new functions refactored in https://github.com/sclorg/container-common-scripts/pull/155/files
- enables tests to be run in a remote OCP4 cluster