### PR TITLE
Test the latest version in imagestreams

### DIFF
--- a/test/check_imagestreams.py
+++ b/test/check_imagestreams.py
@@ -1,0 +1,1 @@
+../common/check_imagestreams.py

--- a/test/run-openshift-local-cluster
+++ b/test/run-openshift-local-cluster
@@ -50,6 +50,16 @@ function test_file_upload() {
   ct_os_delete_project
 }
 
+test_latest_imagestreams() {
+  local result=1
+  # Switch to root directory of a container
+  pushd "${test_dir}/../.." >/dev/null || return 1
+  ct_check_latest_imagestreams
+  result=$?
+  popd >/dev/null || return 1
+  return $result
+}
+
 ct_os_cluster_up
 
 # test local app
@@ -79,6 +89,8 @@ else
 fi
 
 test_file_upload "$IMAGE_NAME"
+
+test_latest_imagestreams
 
 # Check the imagestream
 test_php_imagestream


### PR DESCRIPTION
This commit adds check for the latest version in imagestreams.

If the latest version is not present in imagestreams, then the test fails.