### PR TITLE
Bug 1853593: Remove .git folder when building container

### DIFF
--- a/7.2/s2i/bin/assemble
+++ b/7.2/s2i/bin/assemble
@@ -6,6 +6,7 @@ source ${PHP_CONTAINER_SCRIPTS_PATH}/common.sh
 
 shopt -s dotglob
 echo "---> Installing application source..."
+rm -fR /tmp/src/.git
 mv /tmp/src/* ./
 
 # Fix source directory permissions

--- a/7.3/s2i/bin/assemble
+++ b/7.3/s2i/bin/assemble
@@ -6,6 +6,7 @@ source ${PHP_CONTAINER_SCRIPTS_PATH}/common.sh
 
 shopt -s dotglob
 echo "---> Installing application source..."
+rm -fR /tmp/src/.git
 mv /tmp/src/* ./
 
 # Fix source directory permissions

--- a/7.4/s2i/bin/assemble
+++ b/7.4/s2i/bin/assemble
@@ -6,6 +6,7 @@ source ${PHP_CONTAINER_SCRIPTS_PATH}/common.sh
 
 shopt -s dotglob
 echo "---> Installing application source..."
+rm -fR /tmp/src/.git
 mv /tmp/src/* ./
 
 # Fix source directory permissions


### PR DESCRIPTION
Removing the .git directory prior to copying into place in /opt/app-root/src to avoid exposing it via the web server.