### PR TITLE
Add COMPOSER_INSTALLER_OPTIONS to specify version of Composer etc.

### DIFF
--- a/7.3/README.md
+++ b/7.3/README.md
@@ -244,6 +244,8 @@ yourself:
       * Adds a custom composer repository mirror URL to composer configuration. Note: This only affects packages listed in composer.json.
     * **COMPOSER_INSTALLER**
       * Overrides the default URL for downloading Composer of https://getcomposer.org/installer. Useful in disconnected environments.
+    * **COMPOSER_VERSION**
+      * Overrides the default Composer version to download. See https://getcomposer.org/download/ for releases. Useful if you need version 1 or specific version.
     * **COMPOSER_ARGS**
       * Adds extra arguments to the `composer install` command line (for example `--no-dev`).
 

--- a/7.3/README.md
+++ b/7.3/README.md
@@ -245,7 +245,7 @@ yourself:
     * **COMPOSER_INSTALLER**
       * Overrides the default URL for downloading Composer of https://getcomposer.org/installer. Useful in disconnected environments.
     * **COMPOSER_VERSION**
-      * Overrides the default Composer version to download. See https://getcomposer.org/download/ for releases. Useful if you need version 1 or specific version.
+      * Overrides the default Composer version to download. Set to --1 for latest Composer v1, --2 for latest Composer v2. Defaults to v2. For specific versions see https://getcomposer.org/download/.
     * **COMPOSER_ARGS**
       * Adds extra arguments to the `composer install` command line (for example `--no-dev`).
 

--- a/7.3/README.md
+++ b/7.3/README.md
@@ -244,8 +244,8 @@ yourself:
       * Adds a custom composer repository mirror URL to composer configuration. Note: This only affects packages listed in composer.json.
     * **COMPOSER_INSTALLER**
       * Overrides the default URL for downloading Composer of https://getcomposer.org/installer. Useful in disconnected environments.
-    * **COMPOSER_VERSION**
-      * Overrides the default Composer version to download. Set to --1 for latest Composer v1, --2 for latest Composer v2. Defaults to v2. For specific versions see https://getcomposer.org/download/.
+    * **COMPOSER_INSTALLER_OPTIONS**
+      * Pass additional options to the installer, for example --1 for latest v1 of Composer. See https://getcomposer.org/download/ for more options.
     * **COMPOSER_ARGS**
       * Adds extra arguments to the `composer install` command line (for example `--no-dev`).
 

--- a/7.3/s2i/bin/assemble
+++ b/7.3/s2i/bin/assemble
@@ -38,7 +38,12 @@ if [ -f composer.json ]; then
     echo "Download failed, giving up."
     exit 1
   fi
-  php <$TEMPFILE
+
+  if [ -z "$COMPOSER_VERSION" ]; then
+    php <$TEMPFILE
+  else
+    php $TEMPFILE --version="$COMPOSER_VERSION" 
+  fi
 
   if [ "$(ls -a /tmp/artifacts/ 2>/dev/null)" ]; then
     echo "Restoring build artifacts"

--- a/7.3/s2i/bin/assemble
+++ b/7.3/s2i/bin/assemble
@@ -40,10 +40,16 @@ if [ -f composer.json ]; then
   fi
 
   if [ -z "$COMPOSER_VERSION" ]; then
-    php <$TEMPFILE
+    export COMPOSER_VERSION_ARG=""
+  elif [ $COMPOSER_VERSION = "--1" ]; then
+    export COMPOSER_VERSION_ARG="--1"
+  elif [ $COMPOSER_VERSION = "--2" ]; then
+    export COMPOSER_VERSION_ARG="--2"
   else
-    php $TEMPFILE --version="$COMPOSER_VERSION" 
+    export COMPOSER_VERSION_ARG="--version=$COMPOSER_VERSION"
   fi
+
+  php $TEMPFILE $COMPOSER_VERSION_ARG
 
   if [ "$(ls -a /tmp/artifacts/ 2>/dev/null)" ]; then
     echo "Restoring build artifacts"

--- a/7.3/s2i/bin/assemble
+++ b/7.3/s2i/bin/assemble
@@ -38,18 +38,7 @@ if [ -f composer.json ]; then
     echo "Download failed, giving up."
     exit 1
   fi
-
-  if [ -z "$COMPOSER_VERSION" ]; then
-    export COMPOSER_VERSION_ARG=""
-  elif [ $COMPOSER_VERSION = "--1" ]; then
-    export COMPOSER_VERSION_ARG="--1"
-  elif [ $COMPOSER_VERSION = "--2" ]; then
-    export COMPOSER_VERSION_ARG="--2"
-  else
-    export COMPOSER_VERSION_ARG="--version=$COMPOSER_VERSION"
-  fi
-
-  php $TEMPFILE $COMPOSER_VERSION_ARG
+  php $TEMPFILE "$COMPOSER_INSTALLER_OPTIONS"
 
   if [ "$(ls -a /tmp/artifacts/ 2>/dev/null)" ]; then
     echo "Restoring build artifacts"

--- a/7.4/README.md
+++ b/7.4/README.md
@@ -244,8 +244,8 @@ yourself:
       * Adds a custom composer repository mirror URL to composer configuration. Note: This only affects packages listed in composer.json.
     * **COMPOSER_INSTALLER**
       * Overrides the default URL for downloading Composer of https://getcomposer.org/installer. Useful in disconnected environments.
-    * **COMPOSER_VERSION**
-      * Overrides the default Composer version to download. Set to --1 for latest Composer v1, --2 for latest Composer v2. Defaults to v2. For specific versions see https://getcomposer.org/download/.
+    * **COMPOSER_INSTALLER_OPTIONS**
+      * Pass additional options to the installer, for example --1 for latest v1 of Composer. See https://getcomposer.org/download/ for more options.
     * **COMPOSER_ARGS**
       * Adds extra arguments to the `composer install` command line (for example `--no-dev`).
 

--- a/7.4/README.md
+++ b/7.4/README.md
@@ -244,6 +244,8 @@ yourself:
       * Adds a custom composer repository mirror URL to composer configuration. Note: This only affects packages listed in composer.json.
     * **COMPOSER_INSTALLER**
       * Overrides the default URL for downloading Composer of https://getcomposer.org/installer. Useful in disconnected environments.
+    * **COMPOSER_VERSION**
+      * Overrides the default Composer version to download. Set to --1 for latest Composer v1, --2 for latest Composer v2. Defaults to v2. For specific versions see https://getcomposer.org/download/.
     * **COMPOSER_ARGS**
       * Adds extra arguments to the `composer install` command line (for example `--no-dev`).
 

--- a/7.4/s2i/bin/assemble
+++ b/7.4/s2i/bin/assemble
@@ -38,7 +38,18 @@ if [ -f composer.json ]; then
     echo "Download failed, giving up."
     exit 1
   fi
-  php <$TEMPFILE
+
+  if [ -z "$COMPOSER_VERSION" ]; then
+    export COMPOSER_VERSION_ARG=""
+  elif [ $COMPOSER_VERSION = "--1" ]; then
+    export COMPOSER_VERSION_ARG="--1"
+  elif [ $COMPOSER_VERSION = "--2" ]; then
+    export COMPOSER_VERSION_ARG="--2"
+  else
+    export COMPOSER_VERSION_ARG="--version=$COMPOSER_VERSION"
+  fi
+
+  php $TEMPFILE $COMPOSER_VERSION_ARG
 
   if [ "$(ls -a /tmp/artifacts/ 2>/dev/null)" ]; then
     echo "Restoring build artifacts"

--- a/7.4/s2i/bin/assemble
+++ b/7.4/s2i/bin/assemble
@@ -38,18 +38,7 @@ if [ -f composer.json ]; then
     echo "Download failed, giving up."
     exit 1
   fi
-
-  if [ -z "$COMPOSER_VERSION" ]; then
-    export COMPOSER_VERSION_ARG=""
-  elif [ $COMPOSER_VERSION = "--1" ]; then
-    export COMPOSER_VERSION_ARG="--1"
-  elif [ $COMPOSER_VERSION = "--2" ]; then
-    export COMPOSER_VERSION_ARG="--2"
-  else
-    export COMPOSER_VERSION_ARG="--version=$COMPOSER_VERSION"
-  fi
-
-  php $TEMPFILE $COMPOSER_VERSION_ARG
+  php $TEMPFILE "$COMPOSER_INSTALLER_OPTIONS"
 
   if [ "$(ls -a /tmp/artifacts/ 2>/dev/null)" ]; then
     echo "Restoring build artifacts"


### PR DESCRIPTION
Composer install defaults to version 2. Adding support for using version 1.

Please add this to other versions, eg 7.4 as you see fit.