### PR TITLE
imagestream: point centos7 images to quay.io

### DIFF
--- a/imagestreams/php-centos.json
+++ b/imagestreams/php-centos.json
@@ -102,7 +102,7 @@
         },
         "from": {
           "kind": "DockerImage",
-          "name": "docker.io/centos/php-73-centos7:latest"
+          "name": "quay.io/centos7/php-73-centos7:latest"
         },
         "referencePolicy": {
           "type": "Local"


### PR DESCRIPTION
Use quay.io as a source of the images to avoid Docker Hub ratelimiting where possible