### PR TITLE
Fixes ini scan usage

### DIFF
--- a/5.5/s2i/bin/run
+++ b/5.5/s2i/bin/run
@@ -20,7 +20,12 @@ export OPCACHE_MEMORY_CONSUMPTION=${OPCACHE_MEMORY_CONSUMPTION:-16M}
 export OPCACHE_REVALIDATE_FREQ=${OPCACHE_REVALIDATE_FREQ:-2}
 
 export PHPRC=${PHPRC:-/opt/rh/php55/root/etc/php.ini}
-export PHP_INI_SCAN_DIR=${PHP_INI_SCAN_DIR:-/opt/rh/php55/root/etc/php.d}
+
+if [ -z "${PHP_INI_SCAN_DIR:-}" ]; then
+   export PHP_INI_SCAN_DIR=opt/rh/php55/root/etc/php.d
+else
+   export PHP_INI_SCAN_DIR=${PHP_INI_SCAN_DIR}:/opt/rh/php55/root/etc/php.d
+fi
 
 envsubst < /opt/app-root/etc/php.ini.template > /opt/rh/php55/root/etc/php.ini
 envsubst < /opt/app-root/etc/php.d/opcache.ini.template > /opt/rh/php55/root/etc/php.d/opcache.ini

--- a/5.6/s2i/bin/run
+++ b/5.6/s2i/bin/run
@@ -27,7 +27,12 @@ export OPCACHE_MEMORY_CONSUMPTION=${OPCACHE_MEMORY_CONSUMPTION:-128}
 export OPCACHE_REVALIDATE_FREQ=${OPCACHE_REVALIDATE_FREQ:-2}
 
 export PHPRC=${PHPRC:-${PHP_SYSCONF_PATH}/php.ini}
-export PHP_INI_SCAN_DIR=${PHP_INI_SCAN_DIR:-${PHP_SYSCONF_PATH}/php.d}
+
+if [ -z "${PHP_INI_SCAN_DIR:-}" ]; then
+   export PHP_INI_SCAN_DIR=${PHP_SYSCONF_PATH}/php.d
+else
+   export PHP_INI_SCAN_DIR=${PHP_INI_SCAN_DIR}:${PHP_SYSCONF_PATH}/php.d
+fi
 
 envsubst < /opt/app-root/etc/php.ini.template > ${PHP_SYSCONF_PATH}/php.ini
 envsubst < /opt/app-root/etc/php.d/10-opcache.ini.template > ${PHP_SYSCONF_PATH}/php.d/10-opcache.ini

--- a/7.0/s2i/bin/run
+++ b/7.0/s2i/bin/run
@@ -27,7 +27,12 @@ export OPCACHE_MEMORY_CONSUMPTION=${OPCACHE_MEMORY_CONSUMPTION:-128}
 export OPCACHE_REVALIDATE_FREQ=${OPCACHE_REVALIDATE_FREQ:-2}
 
 export PHPRC=${PHPRC:-${PHP_SYSCONF_PATH}/php.ini}
-export PHP_INI_SCAN_DIR=${PHP_INI_SCAN_DIR:-${PHP_SYSCONF_PATH}/php.d}
+
+if [ -z "${PHP_INI_SCAN_DIR:-}" ]; then
+   export PHP_INI_SCAN_DIR=${PHP_SYSCONF_PATH}/php.d
+else
+   export PHP_INI_SCAN_DIR=${PHP_INI_SCAN_DIR}:${PHP_SYSCONF_PATH}/php.d
+fi
 
 envsubst < /opt/app-root/etc/php.ini.template > ${PHP_SYSCONF_PATH}/php.ini
 envsubst < /opt/app-root/etc/php.d/10-opcache.ini.template > ${PHP_SYSCONF_PATH}/php.d/10-opcache.ini

--- a/7.1/s2i/bin/run
+++ b/7.1/s2i/bin/run
@@ -28,7 +28,12 @@ export OPCACHE_MEMORY_CONSUMPTION=${OPCACHE_MEMORY_CONSUMPTION:-128}
 export OPCACHE_REVALIDATE_FREQ=${OPCACHE_REVALIDATE_FREQ:-2}
 
 export PHPRC=${PHPRC:-${PHP_SYSCONF_PATH}/php.ini}
-export PHP_INI_SCAN_DIR=${PHP_INI_SCAN_DIR:-${PHP_SYSCONF_PATH}/php.d}
+
+if [ -z "${PHP_INI_SCAN_DIR:-}" ]; then
+   export PHP_INI_SCAN_DIR=${PHP_SYSCONF_PATH}/php.d
+else
+   export PHP_INI_SCAN_DIR=${PHP_INI_SCAN_DIR}:${PHP_SYSCONF_PATH}/php.d
+fi
 
 envsubst < /opt/app-root/etc/php.ini.template > ${PHP_SYSCONF_PATH}/php.ini
 envsubst < /opt/app-root/etc/php.d/10-opcache.ini.template > ${PHP_SYSCONF_PATH}/php.d/10-opcache.ini

--- a/7.2/s2i/bin/run
+++ b/7.2/s2i/bin/run
@@ -29,7 +29,12 @@ export OPCACHE_REVALIDATE_FREQ=${OPCACHE_REVALIDATE_FREQ:-2}
 export OPCACHE_MAX_FILES=${OPCACHE_MAX_FILES:-4000}
 
 export PHPRC=${PHPRC:-${PHP_SYSCONF_PATH}/php.ini}
-export PHP_INI_SCAN_DIR=${PHP_INI_SCAN_DIR:-${PHP_SYSCONF_PATH}/php.d}
+
+if [ -z "${PHP_INI_SCAN_DIR:-}" ]; then
+   export PHP_INI_SCAN_DIR=${PHP_SYSCONF_PATH}/php.d
+else
+   export PHP_INI_SCAN_DIR=${PHP_INI_SCAN_DIR}:${PHP_SYSCONF_PATH}/php.d
+fi
 
 envsubst < /opt/app-root/etc/php.ini.template > ${PHP_SYSCONF_PATH}/php.ini
 envsubst < /opt/app-root/etc/php.d/10-opcache.ini.template > ${PHP_SYSCONF_PATH}/php.d/10-opcache.ini

--- a/7.3/s2i/bin/run
+++ b/7.3/s2i/bin/run
@@ -29,7 +29,12 @@ export OPCACHE_REVALIDATE_FREQ=${OPCACHE_REVALIDATE_FREQ:-2}
 export OPCACHE_MAX_FILES=${OPCACHE_MAX_FILES:-4000}
 
 export PHPRC=${PHPRC:-${PHP_SYSCONF_PATH}/php.ini}
-export PHP_INI_SCAN_DIR=${PHP_INI_SCAN_DIR:-${PHP_SYSCONF_PATH}/php.d}
+
+if [ -z "${PHP_INI_SCAN_DIR:-}" ]; then
+   export PHP_INI_SCAN_DIR=${PHP_SYSCONF_PATH}/php.d
+else
+   export PHP_INI_SCAN_DIR=${PHP_INI_SCAN_DIR}:${PHP_SYSCONF_PATH}/php.d
+fi
 
 envsubst < /opt/app-root/etc/php.ini.template > ${PHP_SYSCONF_PATH}/php.ini
 envsubst < /opt/app-root/etc/php.d/10-opcache.ini.template > ${PHP_SYSCONF_PATH}/php.d/10-opcache.ini

--- a/7.4/s2i/bin/run
+++ b/7.4/s2i/bin/run
@@ -29,7 +29,12 @@ export OPCACHE_REVALIDATE_FREQ=${OPCACHE_REVALIDATE_FREQ:-2}
 export OPCACHE_MAX_FILES=${OPCACHE_MAX_FILES:-4000}
 
 export PHPRC=${PHPRC:-${PHP_SYSCONF_PATH}/php.ini}
-export PHP_INI_SCAN_DIR=${PHP_INI_SCAN_DIR:-${PHP_SYSCONF_PATH}/php.d}
+
+if [ -z "${PHP_INI_SCAN_DIR:-}" ]; then
+   export PHP_INI_SCAN_DIR=${PHP_SYSCONF_PATH}/php.d
+else
+   export PHP_INI_SCAN_DIR=${PHP_INI_SCAN_DIR}:${PHP_SYSCONF_PATH}/php.d
+fi
 
 envsubst < /opt/app-root/etc/php.ini.template > ${PHP_SYSCONF_PATH}/php.ini
 envsubst < /opt/app-root/etc/php.d/10-opcache.ini.template > ${PHP_SYSCONF_PATH}/php.d/10-opcache.ini


### PR DESCRIPTION
Per the documentation

```text
PHP_INI_SCAN_DIR
Path to scan for additional ini configuration files
```

If you set this value on a running container it will no longer include ${PHP_SYSCONF_PATH}/php.d. This will break the container as normally this directory is populated with the pre-baked in PHP modules.

This change includes the PHP_SYSCONF_PATH so you can include an additional directory in the app code base to scan.

If rejected documentation should be updated to clearly indicate you still need to include the base directory for your container. But this causes a further issue as you have to maintain the exact pathing to the php version compiled into the image. 