### PR TITLE
Bug1901768

### DIFF
--- a/7.3/README.md
+++ b/7.3/README.md
@@ -256,6 +256,8 @@ yourself:
       * Adds a custom composer repository mirror URL to composer configuration. Note: This only affects packages listed in composer.json.
     * **COMPOSER_INSTALLER**
       * Overrides the default URL for downloading Composer of https://getcomposer.org/installer. Useful in disconnected environments.
+    * **COMPOSER_VERSION**
+      * Overrides the default composer version to install (1, 2, preview, snapshot or version="x.y.z")
     * **COMPOSER_ARGS**
       * Adds extra arguments to the `composer install` command line (for example `--no-dev`).
 

--- a/7.3/s2i/bin/assemble
+++ b/7.3/s2i/bin/assemble
@@ -38,7 +38,14 @@ if [ -f composer.json ]; then
     echo "Download failed, giving up."
     exit 1
   fi
-  php <$TEMPFILE
+
+  if [ -z $COMPOSER_VERSION ]; then
+    echo "By default, latest composer will be used. If you want to use v1 please use the environment variable COMPOSER_VERSION=1"
+    php <$TEMPFILE
+  else
+    echo "You set the COMPOSER_VERSION"
+    php <$TEMPFILE -- --$COMPOSER_VERSION
+  fi
 
   if [ "$(ls -a /tmp/artifacts/ 2>/dev/null)" ]; then
     echo "Restoring build artifacts"

--- a/7.4/README.md
+++ b/7.4/README.md
@@ -256,6 +256,8 @@ yourself:
       * Adds a custom composer repository mirror URL to composer configuration. Note: This only affects packages listed in composer.json.
     * **COMPOSER_INSTALLER**
       * Overrides the default URL for downloading Composer of https://getcomposer.org/installer. Useful in disconnected environments.
+    * **COMPOSER_VERSION**
+      * Overrides the default composer version to install (1, 2, preview, snapshot or version="x.y.z")
     * **COMPOSER_ARGS**
       * Adds extra arguments to the `composer install` command line (for example `--no-dev`).
 

--- a/7.4/s2i/bin/assemble
+++ b/7.4/s2i/bin/assemble
@@ -38,7 +38,14 @@ if [ -f composer.json ]; then
     echo "Download failed, giving up."
     exit 1
   fi
-  php <$TEMPFILE
+
+  if [ -z $COMPOSER_VERSION ]; then
+    echo "By default, latest composer will be used. If you want to use v1 please use the environment variable COMPOSER_VERSION=1"
+    php <$TEMPFILE
+  else
+    echo "You set the COMPOSER_VERSION"
+    php <$TEMPFILE -- --$COMPOSER_VERSION
+  fi
 
   if [ "$(ls -a /tmp/artifacts/ 2>/dev/null)" ]; then
     echo "Restoring build artifacts"


### PR DESCRIPTION
Proposal from https://bugzilla.redhat.com/1901768

Small changes + documentation

Can use:

    COMPOSER_VERSION=1 for latest version 1 (1.10.17 for now)
    COMPOSER_VERSION=2 for latest version 2 (2.0.7 for now)
    COMPOSER_VERSION=snapshot for git snapshot
    COMPOSER_VERSION=preview for beta version (none for now, so 2.0.7)
    COMPOSER_MAJOR_VERSION=version=x.y.z for any specific version

Default is to use the latest stable release (2.0.7 for now)

#320 