### PR TITLE
Use groupified apiVersion

### DIFF
--- a/imagestreams/php-centos.json
+++ b/imagestreams/php-centos.json
@@ -1,6 +1,6 @@
 {
   "kind": "ImageStream",
-  "apiVersion": "v1",
+  "apiVersion": "image.openshift.io/v1",
   "metadata": {
     "name": "php",
     "annotations": {

--- a/imagestreams/php-rhel-aarch64.json
+++ b/imagestreams/php-rhel-aarch64.json
@@ -1,6 +1,6 @@
 {
   "kind": "ImageStream",
-  "apiVersion": "v1",
+  "apiVersion": "image.openshift.io/v1",
   "metadata": {
     "name": "php",
     "annotations": {

--- a/imagestreams/php-rhel.json
+++ b/imagestreams/php-rhel.json
@@ -1,6 +1,6 @@
 {
   "kind": "ImageStream",
-  "apiVersion": "v1",
+  "apiVersion": "image.openshift.io/v1",
   "metadata": {
     "name": "php",
     "annotations": {


### PR DESCRIPTION
Non-groupified objects were deprecated in OCP 4.7.
