### PR TITLE
php-7.3 reached EOL for RHEL8.

### DIFF
--- a/7.3/README.md
+++ b/7.3/README.md
@@ -3,7 +3,7 @@ PHP 7.3 container image
 
 This container image includes PHP 7.3 as a [S2I](https://github.com/openshift/source-to-image) base image for your PHP 7.3 applications.
 Users can choose between RHEL and CentOS based builder images.
-The RHEL UBI images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/),
+The RHEL UBI images are available in the [Red Hat Container Catalog](https://catalog.redhat.com/software/containers/search),
 the CentOS images are available on [Quay.io](https://quay.io/organization/centos7),
 and the Fedora images are available in [Fedora Registry](https://registry.fedoraproject.org/).
 The resulting image can be run using [podman](https://github.com/containers/libpod).
@@ -28,7 +28,7 @@ the nodejs itself is included just to make the npm work.
 
 Usage in OpenShift
 ------------------
-In this example, we will assume that you are using the `ubi8/php-73` image, available via `php:73` imagestream tag in Openshift.
+In this example, we will assume that you are using the `ubi7/php-73` image, available via `php:73` imagestream tag in Openshift.
 
 To build a simple [cakephp-sample-app](https://github.com/sclorg/cakephp-ex.git) application in Openshift:
 
@@ -72,10 +72,10 @@ To use the PHP image in a Dockerfile, follow these steps:
 #### 1. Pull a base builder image to build on
 
 ```
-podman pull ubi8/php-73
+podman pull ubi7/php-73
 ```
 
-An UBI image `ubi8/php-73` is used in this example. This image is usable and freely redistributable under the terms of the UBI End User License Agreement (EULA). See more about UBI at [UBI FAQ](https://developers.redhat.com/articles/ubi-faq).
+An UBI image `ubi7/php-73` is used in this example. This image is usable and freely redistributable under the terms of the UBI End User License Agreement (EULA). See more about UBI at [UBI FAQ](https://developers.redhat.com/articles/ubi-faq).
 
 #### 2. Pull an application code
 
@@ -97,7 +97,7 @@ For all these three parts, users can either setup all manually and use commands 
 
 ##### 3.1. To use your own setup, create a Dockerfile with this content:
 ```
-FROM ubi8/php-73
+FROM ubi7/php-73
 
 # Add application sources
 ADD app-src .
@@ -123,7 +123,7 @@ CMD /usr/libexec/s2i/run
 
 ##### 3.2. To use the Source-to-Image scripts and build an image using a Dockerfile, create a Dockerfile with this content:
 ```
-FROM ubi8/php-73
+FROM ubi7/php-73
 
 # Add application sources to a directory that the assemble script expects them
 # and set permissions so that the container runs without root access

--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ Installation
 To build a PHP image, choose either the CentOS or RHEL based image:
 *  **RHEL based image**
 
-    These images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/#/registry.access.redhat.com/rhscl/php-73-rhel7).
+    These images are available in the [Red Hat Container Catalog](https://catalog.redhat.com/software/containers/ubi8/php-74/5f521244e05bbcd88f128b63).
     To download it run:
 
     ```
-    $ podman pull registry.access.redhat.com/rhscl/php-73-rhel7
+    $ podman pull registry.access.redhat.com/ubi8/php-74
     ```
 
     To build a RHEL based PHP image, you need to run the build on a properly
@@ -52,7 +52,7 @@ To build a PHP image, choose either the CentOS or RHEL based image:
     ```
     $ git clone --recursive https://github.com/sclorg/s2i-php-container.git
     $ cd s2i-php-container
-    $ make build TARGET=rhel7 VERSIONS=7.3
+    $ make build TARGET=rhel8 VERSIONS=7.4
     ```
 
 *  **CentOS based image**
@@ -92,12 +92,12 @@ Users can choose between testing a PHP test application based on a RHEL or CentO
 
     This image is not available as a trusted build in [Docker Index](https://index.docker.io).
 
-    To test a RHEL7 based PHP-7.3 image, you need to run the test on a properly
+    To test a RHEL8 based PHP-7.4 image, you need to run the test on a properly
     subscribed RHEL machine.
 
     ```
     $ cd s2i-php-container
-    $ make test TARGET=rhel7 VERSIONS=7.3
+    $ make test TARGET=rhel8 VERSIONS=7.4
     ```
 
 *  **CentOS based image**

--- a/imagestreams/php-rhel-aarch64.json
+++ b/imagestreams/php-rhel-aarch64.json
@@ -47,26 +47,6 @@
         "referencePolicy": {
           "type": "Local"
         }
-      },
-      {
-        "name": "7.3-ubi8",
-        "annotations": {
-          "openshift.io/display-name": "PHP 7.3 (UBI 8)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run PHP 7.3 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/7.3/README.md.",
-          "iconClass": "icon-php",
-          "tags": "builder,php",
-          "supports":"php:7.3,php",
-          "version": "7.3",
-          "sampleRepo": "https://github.com/sclorg/cakephp-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.redhat.io/ubi8/php-73:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
       }
     ]
   }

--- a/imagestreams/php-rhel.json
+++ b/imagestreams/php-rhel.json
@@ -49,26 +49,6 @@
         }
       },
       {
-        "name": "7.3-ubi8",
-        "annotations": {
-          "openshift.io/display-name": "PHP 7.3 (UBI 8)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run PHP 7.3 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/7.3/README.md.",
-          "iconClass": "icon-php",
-          "tags": "builder,php",
-          "supports":"php:7.3,php",
-          "version": "7.3",
-          "sampleRepo": "https://github.com/sclorg/cakephp-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.redhat.io/ubi8/php-73:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
         "name": "7.3-ubi7",
         "annotations": {
           "openshift.io/display-name": "PHP 7.3 (UBI 7)",

--- a/test/run-openshift-local-cluster
+++ b/test/run-openshift-local-cluster
@@ -94,8 +94,7 @@ test_file_upload "$IMAGE_NAME"
 # Check the imagestream
 test_php_imagestream
 
-# Version 7.4 is not supported for RHEL7 in imagestreams yet
-# Let's disable tests
+# CentOS-7 and RHEL-7 does not have image streams for 7.4 yet.
 # test_latest_imagestreams
 
 OS_TESTSUITE_RESULT=0


### PR DESCRIPTION
This pull request removes PHP-7.3 for RHEL8 from upstream repositories.

It updates:

- imagestreams files
- README.md file
- 7.3/README.md file
- comment out `test_latest_imagestreams`

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>