### PR TITLE
Add support CentOS Stream 9 to GitHub Actions

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -9,7 +9,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [7.3, 7.4]
+        version: [7.3, 7.4, 8.0]
+        include:
+          - dockerfile: "Dockerfile"
+            registry_namespace: "centos7"
+            registry_suffix: "-centos7"
+            tag: "centos7"
+          - dockerfile: "Dockerfile.c9s"
+            registry_namespace: "sclorg"
+            registry_suffix: ""
+            tag: "c9s"
+
     steps:
       - uses: actions/checkout@v2
 
@@ -28,32 +38,40 @@ jobs:
           ver="${{ matrix.version }}"
           echo "::set-output name=SHORT_VER::${ver//./}"
 
-      - name: Check if .exclude-centos7 is present in version directory
-        id: check_exclude_centos7_file
+      - name: Login to Quay.io private registry
+        if: ${{ matrix.registry_namespace != 'centos7' }}
+        uses: redhat-actions/podman-login@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_IMAGE_SCLORG_BUILDER_USERNAME }}
+          password: ${{ secrets.QUAY_IMAGE_SCLORG_BUILDER_TOKEN }}
+
+      - name: Check if .exclude-${{ matrix.tag }} is present in version directory
+        id: check_exclude_file
         # https://github.com/marketplace/actions/file-existence
         uses: andstor/file-existence-action@v1
         with:
-          files: "${{ matrix.version }}/.exclude-centos7"
+          files: "${{ matrix.version }}/.exclude-${{ matrix.tag }}"
 
-      - name: Build CentOS7 image
-        if: steps.check_exclude_centos7_file.outputs.files_exists == 'false'
+      - name: Build image
+        if: steps.check_exclude_file.outputs.files_exists == 'false'
         id: build-image
         # https://github.com/marketplace/actions/buildah-build
         uses: redhat-actions/buildah-build@v2
         with:
-          dockerfiles: ${{ matrix.version }}/Dockerfile
-          image: ${{ steps.base-image-name.outputs.image_name}}-${{ steps.short_version.outputs.SHORT_VER }}-centos7
+          dockerfiles: ${{ matrix.version }}/${{ matrix.dockerfile }}
+          image: ${{ steps.base-image-name.outputs.image_name}}-${{ steps.short_version.outputs.SHORT_VER }}${{ matrix.registry_suffix }}
           context: ${{ matrix.version }}
-          tags: latest 1 ${{ github.sha }}
+          tags: latest ${{ matrix.tag }} ${{ github.sha }}
 
       - name: Push CentOS7 image to Quay.io
-        if: steps.check_exclude_centos7_file.outputs.files_exists == 'false'
+        if: steps.check_exclude_file.outputs.files_exists == 'false'
         id: push-to-quay
         uses: redhat-actions/push-to-registry@v2.2
         with:
           image: ${{ steps.build-image.outputs.image }}
           tags: ${{ steps.build-image.outputs.tags }}
-          registry: quay.io/centos7
+          registry: quay.io/${{ matrix.registry_namespace }}
           username: ${{ secrets.QUAY_IMAGE_BUILDER_USERNAME }}
           password: ${{ secrets.QUAY_IMAGE_BUILDER_TOKEN }}
 

--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -17,13 +17,13 @@ jobs:
             os_test: "fedora"
             context: "Fedora"
             compose: "CentOS-7"
-            tmt_url: "http://artifacts.dev.testing-farm.io/"
+            tmt_url: "http://artifacts.testing-farm.io/"
             tmt_repo: "https://github.com/sclorg/sclorg-testing-farm"
           - tmt_plan: "centos7"
             os_test: "centos7"
             context: "CentOS7"
             compose: "CentOS-7"
-            tmt_url: "http://artifacts.dev.testing-farm.io/"
+            tmt_url: "http://artifacts.testing-farm.io/"
             tmt_repo: "https://github.com/sclorg/sclorg-testing-farm"
           - tmt_plan: "rhel7-docker"
             os_test: "rhel7"
@@ -37,6 +37,13 @@ jobs:
             compose: "RHEL-8.3.1-Released"
             tmt_url: "http://artifacts.osci.redhat.com/testing-farm/"
             tmt_repo: "https://gitlab.cee.redhat.com/platform-eng-core-services/sclorg-tmt-plans"
+          - tmt_plan: "c9s"
+            os_test: "c9s"
+            context: "CentOS Stream 9"
+            compose: "CentOS-Stream-9"
+            tmt_url: "http://artifacts.testing-farm.io/"
+            tmt_repo: "https://github.com/sclorg/sclorg-testing-farm"
+
     if: |
       github.event.issue.pull_request
       && (contains(github.event.comment.body, '[test]') || contains(github.event.comment.body, '[test-all]'))
@@ -80,12 +87,12 @@ jobs:
             --data @pending.json
           echo "::set-output name=GITHUB_REPOSITORY::$GITHUB_REPOSITORY"
 
-      - name: Schedule a test on Testing Farm
+      - name: Schedule a tests on Testing Farm
         id: sched_test
         run: |
           # Update ubuntu-20.04 in order to install curl and jq
           sudo apt update && sudo apt -y install curl jq
-          if [ "${{ matrix.tmt_plan }}" == "fedora" ] || [ "${{ matrix.tmt_plan }}" == "centos7" ]; then
+          if [ "${{ matrix.tmt_plan }}" == "fedora" ] || [ "${{ matrix.tmt_plan }}" == "centos7" ] || [ "${{ matrix.tmt_plan }}" == "c9s" ]; then
             api_key="${{ secrets.TF_PUBLIC_API_KEY }}"
             branch_name="main"
           else


### PR DESCRIPTION
This pull request adds support CentOS Stream 9 to GitHub Actions.

s2i-php-container is now tested also in CentOS Stream 9.
And the php-8.0 image is also pushed to quay.io repository.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>