### PR TITLE
Switch c9s from public to internal

### DIFF
--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -40,8 +40,8 @@ jobs:
           - tmt_plan: "c9s"
             os_test: "c9s"
             context: "CentOS Stream 9"
-            compose: "CentOS-Stream-9"
-            tmt_url: "http://artifacts.dev.testing-farm.io"
+            compose: "1MT-CentOS-Stream-9"
+            tmt_url: "http://artifacts.osci.redhat.com/testing-farm"
             tmt_repo: "https://github.com/sclorg/sclorg-testing-farm"
 
     if: |
@@ -92,7 +92,7 @@ jobs:
         run: |
           # Update ubuntu-20.04 in order to install curl and jq
           sudo apt update && sudo apt -y install curl jq
-          if [ "${{ matrix.tmt_plan }}" == "fedora" ] || [ "${{ matrix.tmt_plan }}" == "centos7" ] || [ "${{ matrix.tmt_plan }}" == "c9s" ]; then
+          if [ "${{ matrix.tmt_plan }}" == "fedora" ] || [ "${{ matrix.tmt_plan }}" == "centos7" ]; then
             api_key="${{ secrets.TF_PUBLIC_API_KEY }}"
             branch_name="main"
           else


### PR DESCRIPTION
We need to have access to CentOS Stream9 koji builds
which is not possible with public one.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>