### PR TITLE
Support build and testing php-80 on RHEL9 host

### DIFF
--- a/8.0/Dockerfile.rhel9
+++ b/8.0/Dockerfile.rhel9
@@ -1,0 +1,88 @@
+FROM ubi9/s2i-base:1
+
+# This image provides an Apache+PHP environment for running PHP
+# applications.
+
+EXPOSE 8080
+EXPOSE 8443
+
+# Description
+# This image provides an Apache 2.4 + PHP 8.0 environment for running PHP applications.
+# Exposed ports:
+# * 8080 - alternative port for http
+
+ENV PHP_VERSION=8.0 \
+    PHP_VER_SHORT=80 \
+    NAME=php
+
+ENV SUMMARY="Platform for building and running PHP $PHP_VERSION applications" \
+    DESCRIPTION="PHP $PHP_VERSION available as container is a base platform for \
+building and running various PHP $PHP_VERSION applications and frameworks. \
+PHP is an HTML-embedded scripting language. PHP attempts to make it easy for developers \
+to write dynamically generated web pages. PHP also offers built-in database integration \
+for several commercial and non-commercial database management systems, so writing \
+a database-enabled webpage with PHP is fairly simple. The most common use of PHP coding \
+is probably as a replacement for CGI scripts."
+
+LABEL summary="${SUMMARY}" \
+      description="${DESCRIPTION}" \
+      io.k8s.description="${DESCRIPTION}" \
+      io.k8s.display-name="Apache 2.4 with PHP ${PHP_VERSION}" \
+      io.openshift.expose-services="8080:http" \
+      io.openshift.tags="builder,${NAME},${NAME}${PHP_VER_SHORT},${NAME}-${PHP_VER_SHORT}" \
+      io.openshift.s2i.scripts-url="image:///usr/libexec/s2i" \
+      io.s2i.scripts-url="image:///usr/libexec/s2i" \
+      name="ubi9/${NAME}-${PHP_VER_SHORT}" \
+      com.redhat.component="${NAME}-${PHP_VER_SHORT}-container" \
+      version="1" \
+      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI" \
+      help="For more information visit https://github.com/sclorg/s2i-${NAME}-container" \
+      usage="s2i build https://github.com/sclorg/s2i-php-container.git --context-dir=${PHP_VERSION}/test/test-app ubi9/${NAME}-${PHP_VER_SHORT} sample-server" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
+
+# Install Apache httpd and PHP
+RUN INSTALL_PKGS="php php-fpm php-mysqlnd php-pgsql php-bcmath \
+                  php-gd php-intl php-ldap php-mbstring php-pdo \
+                  php-process php-soap php-opcache php-xml \
+                  php-gmp php-pecl-apcu php-pecl-zip mod_ssl hostname" && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    yum reinstall -y tzdata && \
+    rpm -V $INSTALL_PKGS && \
+    yum -y clean all --enablerepo='*'
+
+ENV PHP_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/php/ \
+    APP_DATA=${APP_ROOT}/src \
+    PHP_DEFAULT_INCLUDE_PATH=/usr/share/pear \
+    PHP_SYSCONF_PATH=/etc \
+    PHP_HTTPD_CONF_FILE=php.conf \
+    PHP_FPM_CONF_D_PATH=/etc/php-fpm.d \
+    PHP_FPM_CONF_FILE=www.conf \
+    PHP_FPM_RUN_DIR=/run/php-fpm \
+    PHP_MAIN_FPM_CONF_FILE=/etc/php-fpm.conf \
+    PHP_FPM_LOG_PATH=/var/log/php-fpm \
+    HTTPD_CONFIGURATION_PATH=${APP_ROOT}/etc/conf.d \
+    HTTPD_MAIN_CONF_PATH=/etc/httpd/conf \
+    HTTPD_MAIN_CONF_D_PATH=/etc/httpd/conf.d \
+    HTTPD_MODULES_CONF_D_PATH=/etc/httpd/conf.modules.d \
+    HTTPD_VAR_RUN=/var/run/httpd \
+    HTTPD_DATA_PATH=/var/www \
+    HTTPD_DATA_ORIG_PATH=/var/www \
+    HTTPD_VAR_PATH=/var
+
+# Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH
+COPY ./s2i/bin/ $STI_SCRIPTS_PATH
+
+# Copy extra files to the image.
+COPY ./root/ /
+
+# Reset permissions of filesystem to default values
+RUN /usr/libexec/container-setup && rpm-file-permissions
+
+# RPM uses a wrong file in the config
+# Related: https://bugzilla.redhat.com/show_bug.cgi?id=2092356
+RUN sed -i "s/mod_php7.c/mod_php.c/" /etc/httpd/conf.d/php.conf
+
+USER 1001
+
+# Set the default CMD to print the usage of the language image
+CMD $STI_SCRIPTS_PATH/usage

--- a/8.0/README.md
+++ b/8.0/README.md
@@ -5,7 +5,7 @@ This container image includes PHP 8.0 as a [S2I](https://github.com/openshift/so
 Users can choose between RHEL and CentOS Stream based builder images.
 The RHEL UBI images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/),
 the CentOS Stream images are available on [Quay.io](https://quay.io/organization/sclorg),
-and the Fedora images are available in [Fedora Registry](https://registry.fedoraproject.org/).
+and the Fedora images are available in [Quay.io](https://quay.io/organization/fedora).
 The resulting image can be run using [podman](https://github.com/containers/libpod).
 
 Note: while the examples in this README are calling `podman`, you can replace any such calls by `docker` with the same arguments
@@ -320,7 +320,7 @@ See also
 Dockerfile and other sources are available on https://github.com/sclorg/s2i-php-container.
 In that repository you also can find another versions of Python environment Dockerfiles.
 Dockerfile for CentOS is called `Dockerfile`, Dockerfile for RHEL7 is called `Dockerfile.rhel7`,
-for RHEL8 it's `Dockerfile.rhel8` and the Fedora Dockerfile is called Dockerfile.fedora.
+for RHEL8 it's `Dockerfile.rhel8`, for RHEL9 it's `Dockerfile.rhel9` and the Fedora Dockerfile is called Dockerfile.fedora.
 
 Security Implications
 ---------------------

--- a/8.0/root/usr/libexec/container-setup
+++ b/8.0/root/usr/libexec/container-setup
@@ -26,7 +26,7 @@ else
   rm -f /opt/app-root/etc/scl_enable
 fi
 
-if head "/etc/redhat-release" | grep -q -e "^Red Hat Enterprise Linux release 8" -e "Fedora" -e "^CentOS Stream release 9"; then
+if head "/etc/redhat-release" | grep -q -e "^Red Hat Enterprise Linux release 8" -e "^Red Hat Enterprise Linux release 9" -e "Fedora" -e "^CentOS Stream release 9"; then
     /usr/libexec/httpd-ssl-gencerts
 fi
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
 PHP Docker images
 =================
-s2i-php-container 7.3 Quay.io status: [![Docker Repository on Quay](https://quay.io/repository/centos7/php-73-centos7/status "Docker Repository on Quay")](https://quay.io/repository/centos7/php-73-centos7)
 
-s2i-php-container 7.4 Quay.io status: [![Docker Repository on Quay](https://quay.io/repository/centos7/php-74-centos7/status "Docker Repository on Quay")](https://quay.io/repository/centos7/php-74-centos7)
+[![Build and push images to Quay.io registry](https://github.com/sclorg/s2i-php-container/actions/workflows/build-and-push.yml/badge.svg)](https://github.com/sclorg/s2i-php-container/actions/workflows/build-and-push.yml)
 
+Images available on Quay are:
+* CentOS 7 [php-72](https://quay.io/repository/centos7/php-72-centos7)
+* CentOS 7 [php-73](https://quay.io/repository/centos7/php-73-centos7)
+* CentOS 7 [php-74](https://quay.io/repository/centos7/php-74-centos7)
+* CentOS Stream 9 [php-74](https://quay.io/repository/sclorg/php-74-c9s)
+* Fedora [php-80](https://quay.io/repository/fedora/php-80)
 
 This repository contains the source for building various versions of
 the PHP application as a reproducible Docker image using
@@ -30,6 +35,7 @@ PHP versions currently supported are:
 RHEL versions currently supported are:
 * RHEL7
 * RHEL8
+* RHEL9
 
 CentOS versions currently supported are:
 * CentOS7


### PR DESCRIPTION
This pull request adds support for building and testing PHP-80 container on RHEL9 host.

It also updates README.md files with references to Quay.io

Diff between C9S and RHEL9 Dockerfile is here:

```bash
$ diff 8.0/Dockerfile.c9s 8.0/Dockerfile.rhel9
1c1
< FROM quay.io/sclorg/s2i-base-c9s:c9s
---
> FROM ubi9/s2i-base:1
10c10
< # This image provides an Apache 2.4 + PHP 7.4 environment for running PHP applications.
---
> # This image provides an Apache 2.4 + PHP 8.0 environment for running PHP applications.
35c35
<       name="sclorg/${NAME}-${PHP_VER_SHORT}-c9s" \
---
>       name="ubi9/${NAME}-${PHP_VER_SHORT}" \
40c40
<       usage="s2i build https://github.com/sclorg/s2i-php-container.git --context-dir=${PHP_VERSION}/test/test-app sclorg/${NAME}-${PHP_VER_SHORT}-c9s sample-server" \
---
>       usage="s2i build https://github.com/sclorg/s2i-php-container.git --context-dir=${PHP_VERSION}/test/test-app ubi9/${NAME}-${PHP_VER_SHORT} sample-server" \
80a81,84
> # RPM uses a wrong file in the config
> # Related: https://bugzilla.redhat.com/show_bug.cgi?id=2092356
> RUN sed -i "s/mod_php7.c/mod_php.c/" /etc/httpd/conf.d/php.conf
>
```

Diff between RHEL8 and RHEL9 Dockerfile is here:

```bash
$ diff 8.0/Dockerfile.rhel8 8.0/Dockerfile.rhel9
1c1
< FROM ubi8/s2i-base:1
---
> FROM ubi9/s2i-base:1
35c35
<       name="ubi8/${NAME}-${PHP_VER_SHORT}" \
---
>       name="ubi9/${NAME}-${PHP_VER_SHORT}" \
40c40
<       usage="s2i build https://github.com/sclorg/s2i-php-container.git --context-dir=${PHP_VERSION}/test/test-app ubi8/${NAME}-${PHP_VER_SHORT} sample-server" \
---
>       usage="s2i build https://github.com/sclorg/s2i-php-container.git --context-dir=${PHP_VERSION}/test/test-app ubi9/${NAME}-${PHP_VER_SHORT} sample-server" \
44,46c44,45
< RUN yum -y module enable php:$PHP_VERSION && \
<     INSTALL_PKGS="php php-fpm php-mysqlnd php-pgsql php-bcmath \
<                   php-gd php-intl php-json php-ldap php-mbstring php-pdo \
---
> RUN INSTALL_PKGS="php php-fpm php-mysqlnd php-pgsql php-bcmath \
>                   php-gd php-intl php-ldap php-mbstring php-pdo \
58a58,62
>     PHP_FPM_CONF_D_PATH=/etc/php-fpm.d \
>     PHP_FPM_CONF_FILE=www.conf \
>     PHP_FPM_RUN_DIR=/run/php-fpm \
>     PHP_MAIN_FPM_CONF_FILE=/etc/php-fpm.conf \
>     PHP_FPM_LOG_PATH=/var/log/php-fpm \
```
