### PR TITLE
Support cvp

### DIFF
--- a/7.3/test/test-openshift.yaml
+++ b/7.3/test/test-openshift.yaml
@@ -1,0 +1,1 @@
+../../test/test-openshift.yaml

--- a/7.4/test/test-openshift.yaml
+++ b/7.4/test/test-openshift.yaml
@@ -1,0 +1,1 @@
+../../test/test-openshift.yaml

--- a/8.0/test/test-openshift.yaml
+++ b/8.0/test/test-openshift.yaml
@@ -1,0 +1,1 @@
+../../test/test-openshift.yaml

--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -10,9 +10,9 @@
 
 THISDIR=$(dirname ${BASH_SOURCE[0]})
 
-source ${THISDIR}/test-lib-php.sh
-source ${THISDIR}/test-lib-openshift.sh
-source ${THISDIR}/test-lib-remote-openshift.sh
+source "${THISDIR}/test-lib-php.sh"
+source "${THISDIR}/test-lib-openshift.sh"
+source "${THISDIR}/test-lib-remote-openshift.sh"
 
 TEST_LIST="\
 test_php_integration
@@ -28,6 +28,8 @@ ct_os_set_ocp4
 oc version
 
 ct_os_check_login || exit 1
+
+ct_os_tag_image_for_cvp "php"
 
 set -u
 

--- a/test/test-lib-php.sh
+++ b/test/test-lib-php.sh
@@ -21,7 +21,7 @@ function test_php_integration() {
 # Check the imagestream
 function test_php_imagestream() {
   case ${OS} in
-    rhel7|centos7) ;;
+    rhel7|centos7|rhel8) ;;
     *) echo "Imagestream testing not supported for $OS environment." ; return 0 ;;
   esac
 

--- a/test/test-openshift.yaml
+++ b/test/test-openshift.yaml
@@ -1,0 +1,1 @@
+../common/test-openshift.yaml


### PR DESCRIPTION
This pull request add support for testing php-container in CVP pipeline

* `common` directory is updated into latest
* `test-openshift.yaml` file is added into `test`, `7.3`, `7.4` and `8.0` directories
* `test-lib-php.sh` add support for testing imagestreams in RHEL8
* `run-openshift-remote-cluster` tags image into OpenShift 4 