### PR TITLE
Add a test in Dockerfile directly to check php version

### DIFF
--- a/7.3/Dockerfile.fedora
+++ b/7.3/Dockerfile.fedora
@@ -42,6 +42,7 @@ RUN INSTALL_PKGS="php php-mysqlnd php-bcmath php-json \
                   php-gmp php-pecl-apcu mod_ssl hostname" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS --nogpgcheck && \
     rpm -V $INSTALL_PKGS && \
+    php -v | grep -qe "v$PHP_VERSION\." && echo "Found VERSION $PHP_VERSION" && \
     yum -y clean all --enablerepo='*'
 
 ENV PHP_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/php/ \

--- a/7.3/Dockerfile.rhel8
+++ b/7.3/Dockerfile.rhel8
@@ -49,6 +49,7 @@ RUN yum -y module enable php:$PHP_VERSION && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     yum reinstall -y tzdata && \
     rpm -V $INSTALL_PKGS && \
+    php -v | grep -qe "v$PHP_VERSION\." && echo "Found VERSION $PHP_VERSION" && \
     yum -y clean all --enablerepo='*'
 
 ENV PHP_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/php/ \

--- a/7.4/Dockerfile.fedora
+++ b/7.4/Dockerfile.fedora
@@ -42,6 +42,7 @@ RUN INSTALL_PKGS="php php-mysqlnd php-bcmath php-json \
                   php-gmp php-pecl-apcu mod_ssl hostname" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS --nogpgcheck && \
     rpm -V $INSTALL_PKGS && \
+    php -v | grep -qe "v$PHP_VERSION\." && echo "Found VERSION $PHP_VERSION" && \
     yum -y clean all --enablerepo='*'
 
 ENV PHP_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/php/ \

--- a/7.4/Dockerfile.rhel8
+++ b/7.4/Dockerfile.rhel8
@@ -49,6 +49,7 @@ RUN yum -y module enable php:$PHP_VERSION && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     yum reinstall -y tzdata && \
     rpm -V $INSTALL_PKGS && \
+    php -v | grep -qe "v$PHP_VERSION\." && echo "Found VERSION $PHP_VERSION" && \
     yum -y clean all --enablerepo='*'
 
 ENV PHP_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/php/ \

--- a/8.0/Dockerfile.c9s
+++ b/8.0/Dockerfile.c9s
@@ -48,6 +48,7 @@ RUN INSTALL_PKGS="php php-fpm php-mysqlnd php-pgsql php-bcmath \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     yum reinstall -y tzdata && \
     rpm -V $INSTALL_PKGS && \
+    php -v | grep -qe "v$PHP_VERSION\." && echo "Found VERSION $PHP_VERSION" && \
     yum -y clean all --enablerepo='*'
 
 ENV PHP_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/php/ \

--- a/8.0/Dockerfile.fedora
+++ b/8.0/Dockerfile.fedora
@@ -43,6 +43,7 @@ RUN INSTALL_PKGS="php php-fpm php-mysqlnd php-bcmath \
                   php-gmp php-pecl-apcu mod_ssl hostname" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS --nogpgcheck && \
     rpm -V $INSTALL_PKGS && \
+    php -v | grep -qe "v$PHP_VERSION\." && echo "Found VERSION $PHP_VERSION" && \
     yum -y clean all --enablerepo='*'
 
 ENV PHP_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/php/ \

--- a/8.0/Dockerfile.rhel8
+++ b/8.0/Dockerfile.rhel8
@@ -49,6 +49,7 @@ RUN yum -y module enable php:$PHP_VERSION && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     yum reinstall -y tzdata && \
     rpm -V $INSTALL_PKGS && \
+    php -v | grep -qe "v$PHP_VERSION\." && echo "Found VERSION $PHP_VERSION" && \
     yum -y clean all --enablerepo='*'
 
 ENV PHP_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/php/ \

--- a/8.0/Dockerfile.rhel9
+++ b/8.0/Dockerfile.rhel9
@@ -48,6 +48,7 @@ RUN INSTALL_PKGS="php php-fpm php-mysqlnd php-pgsql php-bcmath \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     yum reinstall -y tzdata && \
     rpm -V $INSTALL_PKGS && \
+    php -v | grep -qe "v$PHP_VERSION\." && echo "Found VERSION $PHP_VERSION" && \
     yum -y clean all --enablerepo='*'
 
 ENV PHP_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/php/ \


### PR DESCRIPTION
Otherwise when a wrong stream is installed, it's only found by scl test, which is too late in the process and might even go through uncought, especially when the scl test is removed for non-SCL distros at some point.