### PR TITLE
feat: INSTALL_PKGS is now a build argument

### DIFF
--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -41,11 +41,12 @@ LABEL summary="${SUMMARY}" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 # Install Apache httpd and PHP
-RUN yum install -y centos-release-scl && \
-    INSTALL_PKGS="rh-php73 rh-php73-php rh-php73-php-mysqlnd rh-php73-php-pgsql rh-php73-php-bcmath \
+ARG INSTALL_PKGS="rh-php73 rh-php73-php rh-php73-php-mysqlnd rh-php73-php-pgsql rh-php73-php-bcmath \
                   rh-php73-php-gd rh-php73-php-intl rh-php73-php-ldap rh-php73-php-mbstring rh-php73-php-pdo \
                   rh-php73-php-process rh-php73-php-soap rh-php73-php-opcache rh-php73-php-xml \
-                  rh-php73-php-gmp rh-php73-php-pecl-apcu httpd24-mod_ssl" && \
+                  rh-php73-php-gmp rh-php73-php-pecl-apcu httpd24-mod_ssl"
+
+RUN yum install -y centos-release-scl && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS --nogpgcheck && \
     rpm -V $INSTALL_PKGS && \
     yum -y clean all --enablerepo='*'

--- a/7.3/Dockerfile.fedora
+++ b/7.3/Dockerfile.fedora
@@ -36,11 +36,12 @@ LABEL summary="$SUMMARY" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 # Install Apache httpd and PHP
-RUN INSTALL_PKGS="php php-mysqlnd php-bcmath php-json \
+ARG INSTALL_PKGS="php php-mysqlnd php-bcmath php-json \
                   php-gd php-intl php-ldap php-mbstring php-pdo \
                   php-process php-soap php-opcache php-xml \
-                  php-gmp php-pecl-apcu mod_ssl hostname" && \
-    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS --nogpgcheck && \
+                  php-gmp php-pecl-apcu mod_ssl hostname"
+
+RUN yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS --nogpgcheck && \
     rpm -V $INSTALL_PKGS && \
     php -v | grep -qe "v$PHP_VERSION\." && echo "Found VERSION $PHP_VERSION" && \
     yum -y clean all --enablerepo='*'

--- a/7.3/Dockerfile.rhel7
+++ b/7.3/Dockerfile.rhel7
@@ -42,12 +42,13 @@ LABEL summary="${SUMMARY}" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 # Install Apache httpd and PHP
-RUN yum install -y yum-utils && \
-    prepare-yum-repositories rhel-server-rhscl-7-rpms && \
-    INSTALL_PKGS="rh-php73 rh-php73-php rh-php73-php-mysqlnd rh-php73-php-pgsql rh-php73-php-bcmath \
+ARG INSTALL_PKGS="rh-php73 rh-php73-php rh-php73-php-mysqlnd rh-php73-php-pgsql rh-php73-php-bcmath \
                   rh-php73-php-gd rh-php73-php-intl rh-php73-php-ldap rh-php73-php-mbstring rh-php73-php-pdo \
                   rh-php73-php-process rh-php73-php-soap rh-php73-php-opcache rh-php73-php-xml \
-                  rh-php73-php-gmp rh-php73-php-pecl-apcu httpd24-mod_ssl" && \
+                  rh-php73-php-gmp rh-php73-php-pecl-apcu httpd24-mod_ssl"
+
+RUN yum install -y yum-utils && \
+    prepare-yum-repositories rhel-server-rhscl-7-rpms && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum -y clean all --enablerepo='*'

--- a/7.3/Dockerfile.rhel8
+++ b/7.3/Dockerfile.rhel8
@@ -41,11 +41,12 @@ LABEL summary="${SUMMARY}" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 # Install Apache httpd and PHP
-RUN yum -y module enable php:$PHP_VERSION && \
-    INSTALL_PKGS="php php-mysqlnd php-pgsql php-bcmath \
+ARG INSTALL_PKGS="php php-mysqlnd php-pgsql php-bcmath \
                   php-gd php-intl php-json php-ldap php-mbstring php-pdo \
                   php-process php-soap php-opcache php-xml \
-                  php-gmp php-pecl-apcu php-pecl-zip mod_ssl hostname" && \
+                  php-gmp php-pecl-apcu php-pecl-zip mod_ssl hostname"
+
+RUN yum -y module enable php:$PHP_VERSION && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     yum reinstall -y tzdata && \
     rpm -V $INSTALL_PKGS && \

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -41,11 +41,12 @@ LABEL summary="${SUMMARY}" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 # Install Apache httpd and PHP
-RUN yum install -y centos-release-scl && \
-    INSTALL_PKGS="rh-php74 rh-php74-php rh-php74-php-mysqlnd rh-php74-php-pgsql rh-php74-php-bcmath \
+ARG INSTALL_PKGS="rh-php74 rh-php74-php rh-php74-php-mysqlnd rh-php74-php-pgsql rh-php74-php-bcmath \
                   rh-php74-php-gd rh-php74-php-intl rh-php74-php-ldap rh-php74-php-mbstring rh-php74-php-pdo \
                   rh-php74-php-process rh-php74-php-soap rh-php74-php-opcache rh-php74-php-xml \
-                  rh-php74-php-gmp rh-php74-php-pecl-apcu httpd24-mod_ssl" && \
+                  rh-php74-php-gmp rh-php74-php-pecl-apcu httpd24-mod_ssl"
+
+RUN yum install -y centos-release-scl && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS --nogpgcheck && \
     rpm -V $INSTALL_PKGS && \
     yum -y clean all --enablerepo='*'

--- a/7.4/Dockerfile.fedora
+++ b/7.4/Dockerfile.fedora
@@ -36,11 +36,12 @@ LABEL summary="$SUMMARY" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 # Install Apache httpd and PHP
-RUN INSTALL_PKGS="php php-mysqlnd php-bcmath php-json \
+ARG INSTALL_PKGS="php php-mysqlnd php-bcmath php-json \
                   php-gd php-intl php-ldap php-mbstring php-pdo \
                   php-process php-soap php-opcache php-xml \
-                  php-gmp php-pecl-apcu mod_ssl hostname" && \
-    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS --nogpgcheck && \
+                  php-gmp php-pecl-apcu mod_ssl hostname"
+
+RUN yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS --nogpgcheck && \
     rpm -V $INSTALL_PKGS && \
     php -v | grep -qe "v$PHP_VERSION\." && echo "Found VERSION $PHP_VERSION" && \
     yum -y clean all --enablerepo='*'

--- a/7.4/Dockerfile.rhel7
+++ b/7.4/Dockerfile.rhel7
@@ -42,12 +42,13 @@ LABEL summary="${SUMMARY}" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 # Install Apache httpd and PHP
-RUN yum install -y yum-utils && \
-    prepare-yum-repositories rhel-server-rhscl-7-rpms && \
-    INSTALL_PKGS="rh-php74 rh-php74-php rh-php74-php-mysqlnd rh-php74-php-pgsql rh-php74-php-bcmath \
+ARG INSTALL_PKGS="rh-php74 rh-php74-php rh-php74-php-mysqlnd rh-php74-php-pgsql rh-php74-php-bcmath \
                   rh-php74-php-gd rh-php74-php-intl rh-php74-php-ldap rh-php74-php-mbstring rh-php74-php-pdo \
                   rh-php74-php-process rh-php74-php-soap rh-php74-php-opcache rh-php74-php-xml \
-                  rh-php74-php-gmp rh-php74-php-pecl-apcu httpd24-mod_ssl" && \
+                  rh-php74-php-gmp rh-php74-php-pecl-apcu httpd24-mod_ssl"
+
+RUN yum install -y yum-utils && \
+    prepare-yum-repositories rhel-server-rhscl-7-rpms && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum -y clean all --enablerepo='*'

--- a/7.4/Dockerfile.rhel8
+++ b/7.4/Dockerfile.rhel8
@@ -41,11 +41,12 @@ LABEL summary="${SUMMARY}" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 # Install Apache httpd and PHP
-RUN yum -y module enable php:$PHP_VERSION && \
-    INSTALL_PKGS="php php-mysqlnd php-pgsql php-bcmath \
+ARG INSTALL_PKGS="php php-mysqlnd php-pgsql php-bcmath \
                   php-gd php-intl php-json php-ldap php-mbstring php-pdo \
                   php-process php-soap php-opcache php-xml \
-                  php-gmp php-pecl-apcu php-pecl-zip mod_ssl hostname" && \
+                  php-gmp php-pecl-apcu php-pecl-zip mod_ssl hostname"
+
+RUN yum -y module enable php:$PHP_VERSION && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     yum reinstall -y tzdata && \
     rpm -V $INSTALL_PKGS && \

--- a/8.0/Dockerfile.c9s
+++ b/8.0/Dockerfile.c9s
@@ -41,11 +41,12 @@ LABEL summary="${SUMMARY}" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 # Install Apache httpd and PHP
-RUN INSTALL_PKGS="php php-fpm php-mysqlnd php-pgsql php-bcmath \
+ARG INSTALL_PKGS="php php-fpm php-mysqlnd php-pgsql php-bcmath \
                   php-gd php-intl php-ldap php-mbstring php-pdo \
                   php-process php-soap php-opcache php-xml \
-                  php-gmp php-pecl-apcu php-pecl-zip mod_ssl hostname" && \
-    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+                  php-gmp php-pecl-apcu php-pecl-zip mod_ssl hostname"
+
+RUN yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     yum reinstall -y tzdata && \
     rpm -V $INSTALL_PKGS && \
     php -v | grep -qe "v$PHP_VERSION\." && echo "Found VERSION $PHP_VERSION" && \

--- a/8.0/Dockerfile.fedora
+++ b/8.0/Dockerfile.fedora
@@ -37,11 +37,12 @@ LABEL summary="$SUMMARY" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 # Install Apache httpd and PHP
-RUN INSTALL_PKGS="php php-fpm php-mysqlnd php-bcmath \
+ARG INSTALL_PKGS="php php-fpm php-mysqlnd php-bcmath \
                   php-gd php-intl php-ldap php-mbstring php-pdo \
                   php-process php-soap php-opcache php-xml \
-                  php-gmp php-pecl-apcu mod_ssl hostname" && \
-    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS --nogpgcheck && \
+                  php-gmp php-pecl-apcu mod_ssl hostname"
+
+RUN yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS --nogpgcheck && \
     rpm -V $INSTALL_PKGS && \
     php -v | grep -qe "v$PHP_VERSION\." && echo "Found VERSION $PHP_VERSION" && \
     yum -y clean all --enablerepo='*'

--- a/8.0/Dockerfile.rhel8
+++ b/8.0/Dockerfile.rhel8
@@ -41,11 +41,12 @@ LABEL summary="${SUMMARY}" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 # Install Apache httpd and PHP
-RUN yum -y module enable php:$PHP_VERSION && \
-    INSTALL_PKGS="php php-mysqlnd php-pgsql php-bcmath \
+ARG INSTALL_PKGS="php php-mysqlnd php-pgsql php-bcmath \
                   php-gd php-intl php-ldap php-mbstring php-pdo \
                   php-process php-soap php-opcache php-xml \
-                  php-gmp php-pecl-apcu php-pecl-zip mod_ssl hostname" && \
+                  php-gmp php-pecl-apcu php-pecl-zip mod_ssl hostname"
+
+RUN yum -y module enable php:$PHP_VERSION && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     yum reinstall -y tzdata && \
     rpm -V $INSTALL_PKGS && \

--- a/8.0/Dockerfile.rhel9
+++ b/8.0/Dockerfile.rhel9
@@ -41,11 +41,12 @@ LABEL summary="${SUMMARY}" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 # Install Apache httpd and PHP
-RUN INSTALL_PKGS="php php-fpm php-mysqlnd php-pgsql php-bcmath \
+ARG INSTALL_PKGS="php php-fpm php-mysqlnd php-pgsql php-bcmath \
                   php-gd php-intl php-ldap php-mbstring php-pdo \
                   php-process php-soap php-opcache php-xml \
-                  php-gmp php-pecl-apcu php-pecl-zip mod_ssl hostname" && \
-    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+                  php-gmp php-pecl-apcu php-pecl-zip mod_ssl hostname"
+
+RUN yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     yum reinstall -y tzdata && \
     rpm -V $INSTALL_PKGS && \
     php -v | grep -qe "v$PHP_VERSION\." && echo "Found VERSION $PHP_VERSION" && \

--- a/8.1/Dockerfile.c9s
+++ b/8.1/Dockerfile.c9s
@@ -41,11 +41,12 @@ LABEL summary="${SUMMARY}" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 # Install Apache httpd and PHP
-RUN INSTALL_PKGS="php php-fpm php-mysqlnd php-pgsql php-bcmath \
+ARG INSTALL_PKGS="php php-fpm php-mysqlnd php-pgsql php-bcmath \
                   php-gd php-intl php-ldap php-mbstring php-pdo \
                   php-process php-soap php-opcache php-xml \
-                  php-gmp php-pecl-apcu php-pecl-zip mod_ssl hostname" && \
-    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+                  php-gmp php-pecl-apcu php-pecl-zip mod_ssl hostname"
+
+RUN yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     yum reinstall -y tzdata && \
     rpm -V $INSTALL_PKGS && \
     php -v | grep -qe "v$PHP_VERSION\." && echo "Found VERSION $PHP_VERSION" && \

--- a/8.1/Dockerfile.fedora
+++ b/8.1/Dockerfile.fedora
@@ -37,11 +37,12 @@ LABEL summary="$SUMMARY" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 # Install Apache httpd and PHP
-RUN INSTALL_PKGS="php php-fpm php-mysqlnd php-bcmath \
+ARG INSTALL_PKGS="php php-fpm php-mysqlnd php-bcmath \
                   php-gd php-intl php-ldap php-mbstring php-pdo \
                   php-process php-soap php-opcache php-xml \
-                  php-gmp php-pecl-apcu mod_ssl hostname" && \
-    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS --nogpgcheck && \
+                  php-gmp php-pecl-apcu mod_ssl hostname"
+
+RUN yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS --nogpgcheck && \
     rpm -V $INSTALL_PKGS && \
     php -v | grep -qe "v$PHP_VERSION\." && echo "Found VERSION $PHP_VERSION" && \
     yum -y clean all --enablerepo='*'

--- a/8.1/Dockerfile.rhel8
+++ b/8.1/Dockerfile.rhel8
@@ -41,11 +41,12 @@ LABEL summary="${SUMMARY}" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 # Install Apache httpd and PHP
-RUN yum -y module enable php:$PHP_VERSION && \
-    INSTALL_PKGS="php php-mysqlnd php-pgsql php-bcmath \
+ARG INSTALL_PKGS="php php-mysqlnd php-pgsql php-bcmath \
                   php-gd php-intl php-ldap php-mbstring php-pdo \
                   php-process php-soap php-opcache php-xml \
-                  php-gmp php-pecl-apcu php-pecl-zip mod_ssl hostname" && \
+                  php-gmp php-pecl-apcu php-pecl-zip mod_ssl hostname"
+
+RUN yum -y module enable php:$PHP_VERSION && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     yum reinstall -y tzdata && \
     rpm -V $INSTALL_PKGS && \

--- a/8.1/Dockerfile.rhel9
+++ b/8.1/Dockerfile.rhel9
@@ -41,11 +41,12 @@ LABEL summary="${SUMMARY}" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 # Install Apache httpd and PHP
-RUN yum module -y enable php:$PHP_VERSION && \
-    INSTALL_PKGS="php php-fpm php-mysqlnd php-pgsql php-bcmath \
+ARG INSTALL_PKGS="php php-fpm php-mysqlnd php-pgsql php-bcmath \
                   php-gd php-intl php-ldap php-mbstring php-pdo \
                   php-process php-soap php-opcache php-xml \
-                  php-gmp php-pecl-apcu php-pecl-zip mod_ssl hostname" && \
+                  php-gmp php-pecl-apcu php-pecl-zip mod_ssl hostname"
+
+RUN yum module -y enable php:$PHP_VERSION && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     yum reinstall -y tzdata && \
     rpm -V $INSTALL_PKGS && \


### PR DESCRIPTION
Fixes #302.

# Why

We I opened this issue, I needed to add custom packages to these s2i images, but then I needed to fork this repo and editing the package list, or to create a Dockerfile and adding custom packages : in both case I needed to maintain a side repo where we could just have a build argument for that. I could create then a custom build in OpenShift, point it to this repo and add build arg.

# How

In every Dockerfile, I moved the `INSTALL_PKGS` as a build arg. It allows people to rebuild these s2i images and adding with custom packages without having to fork and edit this repo.

# Breaking changes

None, because I added all the listed packages as a default value for this argument. People who don't care won't be affected.

# Attention

The original issue is nearly three years old. At that time I had a clear idea of what to do, maybe the project evolved in a way that my modifications have side effects ? I you can fully test my PR (or maybe CI is already doing this) it would be nice !
