### PR TITLE
Add PyTest container-ci suite for testing PHP container in Openshift 4

### DIFF
--- a/7.3/test/run-openshift
+++ b/7.3/test/run-openshift
@@ -1,1 +1,0 @@
-../../test/run-openshift

--- a/7.3/test/run-openshift-pytest
+++ b/7.3/test/run-openshift-pytest
@@ -1,0 +1,1 @@
+../../test/run-openshift-pytest

--- a/7.3/test/test_deploy_templates.py
+++ b/7.3/test/test_deploy_templates.py
@@ -1,0 +1,1 @@
+../../test/test_deploy_templates.py

--- a/7.3/test/test_latest_imagestreams.py
+++ b/7.3/test/test_latest_imagestreams.py
@@ -1,0 +1,1 @@
+../../test/test_latest_imagestreams.py

--- a/7.3/test/test_s2i_imagestreams.py
+++ b/7.3/test/test_s2i_imagestreams.py
@@ -1,0 +1,1 @@
+../../test/test_s2i_imagestreams.py

--- a/7.3/test/test_s2i_integration.py
+++ b/7.3/test/test_s2i_integration.py
@@ -1,0 +1,1 @@
+../../test/test_s2i_integration.py

--- a/7.4/test/run-openshift
+++ b/7.4/test/run-openshift
@@ -1,1 +1,0 @@
-../../test/run-openshift

--- a/7.4/test/run-openshift-pytest
+++ b/7.4/test/run-openshift-pytest
@@ -1,0 +1,1 @@
+../../test/run-openshift-pytest

--- a/7.4/test/test_deploy_templates.py
+++ b/7.4/test/test_deploy_templates.py
@@ -1,0 +1,1 @@
+../../test/test_deploy_templates.py

--- a/7.4/test/test_latest_imagestreams.py
+++ b/7.4/test/test_latest_imagestreams.py
@@ -1,0 +1,1 @@
+../../test/test_latest_imagestreams.py

--- a/7.4/test/test_s2i_imagestreams.py
+++ b/7.4/test/test_s2i_imagestreams.py
@@ -1,0 +1,1 @@
+../../test/test_s2i_imagestreams.py

--- a/7.4/test/test_s2i_integration.py
+++ b/7.4/test/test_s2i_integration.py
@@ -1,0 +1,1 @@
+../../test/test_s2i_integration.py

--- a/8.0/test/run-openshift-pytest
+++ b/8.0/test/run-openshift-pytest
@@ -1,0 +1,1 @@
+../../test/run-openshift-pytest

--- a/8.0/test/test_deploy_templates.py
+++ b/8.0/test/test_deploy_templates.py
@@ -1,0 +1,1 @@
+../../test/test_deploy_templates.py

--- a/8.0/test/test_latest_imagestreams.py
+++ b/8.0/test/test_latest_imagestreams.py
@@ -1,0 +1,1 @@
+../../test/test_latest_imagestreams.py

--- a/8.0/test/test_s2i_imagestreams.py
+++ b/8.0/test/test_s2i_imagestreams.py
@@ -1,0 +1,1 @@
+../../test/test_s2i_imagestreams.py

--- a/8.0/test/test_s2i_integration.py
+++ b/8.0/test/test_s2i_integration.py
@@ -1,0 +1,1 @@
+../../test/test_s2i_integration.py

--- a/8.1/test/run-openshift
+++ b/8.1/test/run-openshift
@@ -1,1 +1,0 @@
-../../test/run-openshift

--- a/8.1/test/run-openshift-pytest
+++ b/8.1/test/run-openshift-pytest
@@ -1,0 +1,1 @@
+../../test/run-openshift-pytest

--- a/8.1/test/test_dancer_ex_standalone
+++ b/8.1/test/test_dancer_ex_standalone
@@ -1,1 +1,0 @@
-../../test/test_dancer_ex_standalone

--- a/8.1/test/test_dancer_ex_standalone
+++ b/8.1/test/test_dancer_ex_standalone
@@ -1,0 +1,1 @@
+../../test/test_dancer_ex_standalone

--- a/8.1/test/test_dancer_ex_templates
+++ b/8.1/test/test_dancer_ex_templates
@@ -1,1 +1,0 @@
-../../test/test_dancer_ex_templates

--- a/8.1/test/test_dancer_ex_templates
+++ b/8.1/test/test_dancer_ex_templates
@@ -1,0 +1,1 @@
+../../test/test_dancer_ex_templates

--- a/8.1/test/test_deploy_templates.py
+++ b/8.1/test/test_deploy_templates.py
@@ -1,0 +1,1 @@
+../../test/test_deploy_templates.py

--- a/8.1/test/test_imagestreams_quickstart.py
+++ b/8.1/test/test_imagestreams_quickstart.py
@@ -1,1 +1,0 @@
-../../test/test_imagestreams_quickstart.py

--- a/8.1/test/test_imagestreams_quickstart.py
+++ b/8.1/test/test_imagestreams_quickstart.py
@@ -1,0 +1,1 @@
+../../test/test_imagestreams_quickstart.py

--- a/8.1/test/test_latest_imagestreams.py
+++ b/8.1/test/test_latest_imagestreams.py
@@ -1,0 +1,1 @@
+../../test/test_latest_imagestreams.py

--- a/8.1/test/test_s2i_imagestreams.py
+++ b/8.1/test/test_s2i_imagestreams.py
@@ -1,0 +1,1 @@
+../../test/test_s2i_imagestreams.py

--- a/8.1/test/test_s2i_integration.py
+++ b/8.1/test/test_s2i_integration.py
@@ -1,0 +1,1 @@
+../../test/test_s2i_integration.py

--- a/8.2/test/run-openshift
+++ b/8.2/test/run-openshift
@@ -1,1 +1,0 @@
-../../test/run-openshift

--- a/8.2/test/run-openshift-pytest
+++ b/8.2/test/run-openshift-pytest
@@ -1,0 +1,1 @@
+../../test/run-openshift-pytest

--- a/8.2/test/test_deploy_templates.py
+++ b/8.2/test/test_deploy_templates.py
@@ -1,0 +1,1 @@
+../../test/test_deploy_templates.py

--- a/8.2/test/test_latest_imagestreams.py
+++ b/8.2/test/test_latest_imagestreams.py
@@ -1,0 +1,1 @@
+../../test/test_latest_imagestreams.py

--- a/8.2/test/test_s2i_imagestreams.py
+++ b/8.2/test/test_s2i_imagestreams.py
@@ -1,0 +1,1 @@
+../../test/test_s2i_imagestreams.py

--- a/8.2/test/test_s2i_integration.py
+++ b/8.2/test/test_s2i_integration.py
@@ -1,0 +1,1 @@
+../../test/test_s2i_integration.py

--- a/imagestreams/imagestreams.yaml
+++ b/imagestreams/imagestreams.yaml
@@ -17,10 +17,10 @@
         app_versions: ["7.3"]
 
       - name: UBI 8
-        app_versions: ["7.4", "8.0"]
+        app_versions: ["7.4", "8.0", "8.2"]
 
       - name: UBI 9
-        app_versions: ["8.0", "8.1"]
+        app_versions: ["8.0", "8.1", "8.2"]
 
   - filename: php-rhel.json
     latest: "8.0-ubi8"
@@ -29,10 +29,10 @@
         app_versions: ["7.3"]
 
       - name: UBI 8
-        app_versions: ["7.4", "8.0"]
+        app_versions: ["7.4", "8.0", "8.2"]
 
       - name: UBI 9
-        app_versions: ["8.0", "8.1"]
+        app_versions: ["8.0", "8.1", "8.2"]
     custom_tags:
       - name: "7.3"
         distro: UBI 7
@@ -42,8 +42,8 @@
     latest: "8.0-ubi8"
     distros:
       - name: UBI 8
-        app_versions: ["7.4", "8.0"]
+        app_versions: ["7.4", "8.0", "8.2"]
 
       - name: UBI 9
-        app_versions: ["8.0", "8.1"]
+        app_versions: ["8.0", "8.1", "8.2"]
 ...

--- a/imagestreams/php-centos.json
+++ b/imagestreams/php-centos.json
@@ -67,6 +67,25 @@
         }
       },
       {
+        "name": "8.2-ubi8",
+        "annotations": {
+          "openshift.io/display-name": "PHP 8.2 (UBI 8)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run PHP 8.2 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/8.2/README.md.",
+          "iconClass": "icon-php",
+          "tags": "builder,php",
+          "version": "8.2",
+          "sampleRepo": "https://github.com/sclorg/cakephp-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.access.redhat.com/ubi8/php-82:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
         "name": "8.0-ubi9",
         "annotations": {
           "openshift.io/display-name": "PHP 8.0 (UBI 9)",
@@ -99,6 +118,25 @@
         "from": {
           "kind": "DockerImage",
           "name": "registry.access.redhat.com/ubi9/php-81:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "8.2-ubi9",
+        "annotations": {
+          "openshift.io/display-name": "PHP 8.2 (UBI 9)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run PHP 8.2 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/8.2/README.md.",
+          "iconClass": "icon-php",
+          "tags": "builder,php",
+          "version": "8.2",
+          "sampleRepo": "https://github.com/sclorg/cakephp-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.access.redhat.com/ubi9/php-82:latest"
         },
         "referencePolicy": {
           "type": "Local"

--- a/imagestreams/php-rhel-aarch64.json
+++ b/imagestreams/php-rhel-aarch64.json
@@ -48,6 +48,25 @@
         }
       },
       {
+        "name": "8.2-ubi8",
+        "annotations": {
+          "openshift.io/display-name": "PHP 8.2 (UBI 8)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run PHP 8.2 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/8.2/README.md.",
+          "iconClass": "icon-php",
+          "tags": "builder,php",
+          "version": "8.2",
+          "sampleRepo": "https://github.com/sclorg/cakephp-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi8/php-82:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
         "name": "8.0-ubi9",
         "annotations": {
           "openshift.io/display-name": "PHP 8.0 (UBI 9)",
@@ -80,6 +99,25 @@
         "from": {
           "kind": "DockerImage",
           "name": "registry.redhat.io/ubi9/php-81:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "8.2-ubi9",
+        "annotations": {
+          "openshift.io/display-name": "PHP 8.2 (UBI 9)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run PHP 8.2 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/8.2/README.md.",
+          "iconClass": "icon-php",
+          "tags": "builder,php",
+          "version": "8.2",
+          "sampleRepo": "https://github.com/sclorg/cakephp-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi9/php-82:latest"
         },
         "referencePolicy": {
           "type": "Local"

--- a/imagestreams/php-rhel.json
+++ b/imagestreams/php-rhel.json
@@ -67,6 +67,25 @@
         }
       },
       {
+        "name": "8.2-ubi8",
+        "annotations": {
+          "openshift.io/display-name": "PHP 8.2 (UBI 8)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run PHP 8.2 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/8.2/README.md.",
+          "iconClass": "icon-php",
+          "tags": "builder,php",
+          "version": "8.2",
+          "sampleRepo": "https://github.com/sclorg/cakephp-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi8/php-82:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
         "name": "8.0-ubi9",
         "annotations": {
           "openshift.io/display-name": "PHP 8.0 (UBI 9)",
@@ -99,6 +118,25 @@
         "from": {
           "kind": "DockerImage",
           "name": "registry.redhat.io/ubi9/php-81:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "8.2-ubi9",
+        "annotations": {
+          "openshift.io/display-name": "PHP 8.2 (UBI 9)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run PHP 8.2 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/8.2/README.md.",
+          "iconClass": "icon-php",
+          "tags": "builder,php",
+          "version": "8.2",
+          "sampleRepo": "https://github.com/sclorg/cakephp-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi9/php-82:latest"
         },
         "referencePolicy": {
           "type": "Local"

--- a/test/run-openshift-pytest
+++ b/test/run-openshift-pytest
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# IMAGE_NAME specifies a name of the candidate image used for testing.
+# The image has to be available before this script is executed.
+# VERSION specifies the major version of the MariaDB in format of X.Y
+# OS specifies RHEL version (e.g. OS=rhel7)
+#
+
+THISDIR=$(dirname ${BASH_SOURCE[0]})
+
+cd "${THISDIR}" && pytest -srxfapP --showlocals -vv test_{l,s}*.py

--- a/test/run-openshift-pytest
+++ b/test/run-openshift-pytest
@@ -8,4 +8,4 @@
 
 THISDIR=$(dirname ${BASH_SOURCE[0]})
 
-cd "${THISDIR}" && pytest -srxfapP --showlocals -vv test_{l,s}*.py
+cd "${THISDIR}" && python3 -m pytest -s -rxfapP --showlocals -vv test_*.py

--- a/test/test_deploy_templates.py
+++ b/test/test_deploy_templates.py
@@ -1,0 +1,56 @@
+import os
+import sys
+
+from container_ci_suite.openshift import OpenShiftAPI
+from container_ci_suite.utils import check_variables
+
+if not check_variables():
+    print("At least one variable from IMAGE_NAME, OS, SINGLE_VERSION is missing.")
+    sys.exit(1)
+
+
+VERSION = os.getenv("SINGLE_VERSION")
+IMAGE_NAME = os.getenv("IMAGE_NAME")
+OS = os.getenv("TARGET")
+
+if VERSION == "7.4" or VERSION == "8.0":
+    branch_to_test = "4.X"
+    check_msg = "Welcome to CakePHP 4.5"
+elif VERSION == "8.1" or VERSION == "8.2":
+    branch_to_test = "5.X"
+    check_msg = "Welcome to CakePHP 5"
+else:
+    branch_to_test = "master"
+    check_msg = "Welcome to your CakePHP application on OpenShift"
+
+
+class TestDeployTemplate:
+
+    def setup_method(self):
+        self.oc_api = OpenShiftAPI(pod_name_prefix="php-testing", version=VERSION)
+        self.oc_api.import_is("imagestreams/php-rhel.json", "", skip_check=True)
+
+    def teardown_method(self):
+        self.oc_api.delete_project()
+
+    def test_php_template_inside_cluster(self):
+
+        service_name = "php-testing"
+        template_url = self.oc_api.get_raw_url_for_json(
+            container="cakephp-ex", dir="openshift/templates", filename="cakephp.json", branch=branch_to_test
+        )
+        assert self.oc_api.deploy_template_with_image(
+            image_name=IMAGE_NAME,
+            template=template_url,
+            name_in_template="php",
+            openshift_args=[
+                f"SOURCE_REPOSITORY_REF={branch_to_test}",
+                f"PHP_VERSION={VERSION}",
+                f"SOURCE_REPOSITORY_URL=https://github.com/sclorg/cakephp-ex.git",
+                f"NAME={service_name}"
+            ]
+        )
+        assert self.oc_api.template_deployed(name_in_template=service_name)
+        assert self.oc_api.check_response_inside_cluster(
+            name_in_template=service_name, expected_output=check_msg
+        )

--- a/test/test_deploy_templates.py
+++ b/test/test_deploy_templates.py
@@ -1,6 +1,7 @@
 import os
 import sys
 
+import pytest
 from container_ci_suite.openshift import OpenShiftAPI
 from container_ci_suite.utils import check_variables
 
@@ -23,32 +24,55 @@ else:
     branch_to_test = "master"
     check_msg = "Welcome to your CakePHP application on OpenShift"
 
+TAGS = {
+    "rhel8": "-ubi8",
+    "rhel9": "-ubi9"
+}
+TAG = TAGS.get(OS, None)
+
+DEPLOYED_MYSQL_IMAGE = "quay.io/sclorg/mysql-80-c8s"
+IMAGE_SHORT = f"mysql:8.0-el8"
+IMAGE_TAG = f"8.0-el8"
+
 
 class TestDeployTemplate:
 
     def setup_method(self):
         self.oc_api = OpenShiftAPI(pod_name_prefix="php-testing", version=VERSION)
         self.oc_api.import_is("imagestreams/php-rhel.json", "", skip_check=True)
+        assert self.oc_api.upload_image(DEPLOYED_MYSQL_IMAGE, IMAGE_SHORT)
 
     def teardown_method(self):
         self.oc_api.delete_project()
 
-    def test_php_template_inside_cluster(self):
+    @pytest.mark.parametrize(
+        "template",
+        [
+            "cakephp.json",
+        ]
+    )
+    def test_php_template_inside_cluster(self, template):
 
         service_name = "php-testing"
         template_url = self.oc_api.get_raw_url_for_json(
-            container="cakephp-ex", dir="openshift/templates", filename="cakephp.json", branch=branch_to_test
+            container="cakephp-ex", dir="openshift/templates", filename=template, branch=branch_to_test
         )
+        openshift_args = [
+            f"SOURCE_REPOSITORY_REF={branch_to_test}",
+            f"PHP_VERSION={VERSION}{TAG}",
+            f"NAME={service_name}"
+        ]
+        if template != "cakephp.json":
+            openshift_args.extend([
+                f"MYSQL_VERSION={IMAGE_TAG}",
+                f"DATABASE_USER=testu",
+                f"DATABASE_PASSWORD=testp"
+            ])
         assert self.oc_api.deploy_template_with_image(
             image_name=IMAGE_NAME,
             template=template_url,
             name_in_template="php",
-            openshift_args=[
-                f"SOURCE_REPOSITORY_REF={branch_to_test}",
-                f"PHP_VERSION={VERSION}",
-                f"SOURCE_REPOSITORY_URL=https://github.com/sclorg/cakephp-ex.git",
-                f"NAME={service_name}"
-            ]
+            openshift_args=openshift_args
         )
         assert self.oc_api.template_deployed(name_in_template=service_name)
         assert self.oc_api.check_response_inside_cluster(

--- a/test/test_latest_imagestreams.py
+++ b/test/test_latest_imagestreams.py
@@ -1,0 +1,27 @@
+import os
+import sys
+
+from pathlib import Path
+
+from container_ci_suite.imagestreams import ImageStreamChecker
+from container_ci_suite.utils import check_variables
+
+TEST_DIR = Path(os.path.abspath(os.path.dirname(__file__)))
+
+if not check_variables():
+    print("At least one variable from IMAGE_NAME, OS, SINGLE_VERSION is missing.")
+    sys.exit(1)
+
+VERSION = os.getenv("SINGLE_VERSION")
+
+
+# Replacement with 'test_latest_imagestreams'
+class TestLatestImagestreams:
+
+    def setup_method(self):
+        self.isc = ImageStreamChecker(working_dir=TEST_DIR.parent.parent)
+
+    def test_latest_imagestream(self):
+        self.latest_version = self.isc.get_latest_version()
+        assert self.latest_version != ""
+        self.isc.check_imagestreams(self.latest_version)

--- a/test/test_s2i_imagestreams.py
+++ b/test/test_s2i_imagestreams.py
@@ -1,0 +1,39 @@
+import os
+import sys
+
+from container_ci_suite.openshift import OpenShiftAPI
+from container_ci_suite.utils import check_variables
+
+
+if not check_variables():
+    print("At least one variable from IMAGE_NAME, OS, SINGLE_VERSION is missing.")
+    sys.exit(1)
+
+
+VERSION = os.getenv("SINGLE_VERSION")
+IMAGE_NAME = os.getenv("IMAGE_NAME")
+OS = os.getenv("OS")
+
+SHORT_VERSION = "".join(VERSION.split("."))
+
+
+class TestPHPImagestreams:
+
+    def setup_method(self):
+        self.oc_api = OpenShiftAPI(pod_name_prefix="php", version=VERSION)
+
+    def teardown_method(self):
+        self.oc_api.delete_project()
+
+    def test_php_template_inside_cluster(self):
+        service_name = f"php-{SHORT_VERSION}-testing"
+        assert self.oc_api.deploy_imagestream_s2i(
+            imagestream_file="imagestreams/php-rhel.json",
+            image_name=IMAGE_NAME,
+            app="https://github.com/sclorg/s2i-php-container.git",
+            context="test/test-app"
+        )
+        assert self.oc_api.template_deployed(name_in_template=service_name)
+        assert self.oc_api.check_response_inside_cluster(
+            name_in_template=service_name, expected_output="Test PHP passed"
+        )

--- a/test/test_s2i_integration.py
+++ b/test/test_s2i_integration.py
@@ -1,0 +1,36 @@
+import os
+import sys
+
+from container_ci_suite.utils import check_variables
+from container_ci_suite.openshift import OpenShiftAPI
+
+if not check_variables():
+    print("At least one variable from IMAGE_NAME, OS, SINGLE_VERSION is missing.")
+    sys.exit(1)
+
+
+VERSION = os.getenv("SINGLE_VERSION")
+IMAGE_NAME = os.getenv("IMAGE_NAME")
+OS = os.getenv("TARGET")
+
+
+# Replacement with 'test_python_s2i_app_ex'
+class TestS2IPHPTemplate:
+
+    def setup_method(self):
+        self.oc_api = OpenShiftAPI(pod_name_prefix="php-testing", version=VERSION)
+
+    def teardown_method(self):
+        self.oc_api.delete_project()
+
+    def test_php_template_inside_cluster(self):
+        service_name = "php-testing"
+        assert self.oc_api.deploy_s2i_app(
+            image_name=IMAGE_NAME, app=f"https://github.com/sclorg/s2i-php-container.git",
+            context="test/test-app",
+            service_name=service_name
+        )
+        assert self.oc_api.template_deployed(name_in_template=service_name)
+        assert self.oc_api.check_response_inside_cluster(
+            name_in_template=service_name, expected_output="Test PHP passed"
+        )


### PR DESCRIPTION
The pull request is separated into 4 commits:

1) add pytest suite for testing container
2) Removes OpenSHift 3 tests. They are obsolete.
3) Add new 8.2 imagestreams for OpenShift 4
4) Add symlinks to all versions
<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
