### PR TITLE
Remove RHEL-7 - EOL June 2024

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         version: [ "7.3", "7.4", "8.0", "8.1", "8.2" ]
-        os_test: [ "fedora", "rhel7", "rhel8", "rhel9", "c9s"]
+        os_test: [ "fedora", "rhel8", "rhel9", "c9s"]
         test_case: [ "container" ]
 
     if: |

--- a/.github/workflows/openshift-tests.yml
+++ b/.github/workflows/openshift-tests.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         version: [ "7.3", "7.4", "8.0" , "8.1", "8.2" ]
-        os_test: [ "rhel7", "rhel8", "rhel9"]
+        os_test: [ "rhel8", "rhel9"]
         test_case: [ "openshift-4" ]
 
     steps:

--- a/7.3/README.md
+++ b/7.3/README.md
@@ -4,7 +4,6 @@ PHP 7.3 container image
 This container image includes PHP 7.3 as a [S2I](https://github.com/openshift/source-to-image) base image for your PHP 7.3 applications.
 Users can choose between RHEL and CentOS based builder images.
 The RHEL UBI images are available in the [Red Hat Container Catalog](https://catalog.redhat.com/software/containers/search),
-the CentOS images are available on [Quay.io](https://quay.io/organization/centos7),
 and the Fedora images are available in [Fedora Registry](https://registry.fedoraproject.org/).
 The resulting image can be run using [podman](https://github.com/containers/libpod).
 
@@ -319,8 +318,7 @@ See also
 --------
 Dockerfile and other sources are available on https://github.com/sclorg/s2i-php-container.
 In that repository you also can find another versions of Python environment Dockerfiles.
-Dockerfile for CentOS is called `Dockerfile`, Dockerfile for RHEL7 is called `Dockerfile.rhel7`,
-for RHEL8 it's `Dockerfile.rhel8` and the Fedora Dockerfile is called Dockerfile.fedora.
+Dockerfile for RHEL8 is called `Dockerfile.rhel8` and the Fedora Dockerfile is called Dockerfile.fedora.
 
 Security Implications
 ---------------------

--- a/7.4/README.md
+++ b/7.4/README.md
@@ -4,7 +4,6 @@ PHP 7.4 container image
 This container image includes PHP 7.4 as a [S2I](https://github.com/openshift/source-to-image) base image for your PHP 7.4 applications.
 Users can choose between RHEL and CentOS based builder images.
 The RHEL UBI images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/),
-the CentOS images are available on [Quay.io](https://quay.io/organization/centos7),
 and the Fedora images are available in [Fedora Registry](https://registry.fedoraproject.org/).
 The resulting image can be run using [podman](https://github.com/containers/libpod).
 
@@ -319,8 +318,7 @@ See also
 --------
 Dockerfile and other sources are available on https://github.com/sclorg/s2i-php-container.
 In that repository you also can find another versions of Python environment Dockerfiles.
-Dockerfile for CentOS is called `Dockerfile`, Dockerfile for RHEL7 is called `Dockerfile.rhel7`,
-for RHEL8 it's `Dockerfile.rhel8` and the Fedora Dockerfile is called Dockerfile.fedora.
+Dockerfile for RHEL8  is called `Dockerfile.rhel8` and the Fedora Dockerfile is called Dockerfile.fedora.
 
 Security Implications
 ---------------------

--- a/8.0/README.md
+++ b/8.0/README.md
@@ -322,8 +322,7 @@ See also
 --------
 Dockerfile and other sources are available on https://github.com/sclorg/s2i-php-container.
 In that repository you also can find another versions of Python environment Dockerfiles.
-Dockerfile for CentOS is called `Dockerfile`, Dockerfile for RHEL7 is called `Dockerfile.rhel7`,
-for RHEL8 it's `Dockerfile.rhel8`, for RHEL9 it's `Dockerfile.rhel9` and the Fedora Dockerfile is called Dockerfile.fedora.
+Dockerfile for RHEL8 is called  `Dockerfile.rhel8`, Dockerfile for RHEL9 is called  `Dockerfile.rhel9` and the Fedora Dockerfile is called Dockerfile.fedora.
 
 Security Implications
 ---------------------

--- a/8.1/README.md
+++ b/8.1/README.md
@@ -322,8 +322,7 @@ See also
 --------
 Dockerfile and other sources are available on https://github.com/sclorg/s2i-php-container.
 In that repository you also can find another versions of Python environment Dockerfiles.
-Dockerfile for CentOS is called `Dockerfile`, Dockerfile for RHEL7 is called `Dockerfile.rhel7`,
-for RHEL8 it's `Dockerfile.rhel8`, for RHEL9 it's `Dockerfile.rhel9` and the Fedora Dockerfile is called Dockerfile.fedora.
+Dockerfile for RHEL8 is called  `Dockerfile.rhel8`, Dockerfile for RHEL9 is called `Dockerfile.rhel9` and the Fedora Dockerfile is called Dockerfile.fedora.
 
 Security Implications
 ---------------------

--- a/8.2/README.md
+++ b/8.2/README.md
@@ -322,8 +322,7 @@ See also
 --------
 Dockerfile and other sources are available on https://github.com/sclorg/s2i-php-container.
 In that repository you also can find another versions of Python environment Dockerfiles.
-Dockerfile for CentOS is called `Dockerfile`, Dockerfile for RHEL7 is called `Dockerfile.rhel7`,
-for RHEL8 it's `Dockerfile.rhel8`, for RHEL9 it's `Dockerfile.rhel9` and the Fedora Dockerfile is called Dockerfile.fedora.
+Dockerfile for RHEL8 is called `Dockerfile.rhel8`, Dockerfile for RHEL9 is called `Dockerfile.rhel9` and the Fedora Dockerfile is called Dockerfile.fedora.
 
 Security Implications
 ---------------------

--- a/README.md
+++ b/README.md
@@ -4,9 +4,6 @@ PHP Docker images
 [![Build and push images to Quay.io registry](https://github.com/sclorg/s2i-php-container/actions/workflows/build-and-push.yml/badge.svg)](https://github.com/sclorg/s2i-php-container/actions/workflows/build-and-push.yml)
 
 Images available on Quay are:
-* CentOS 7 [php-72](https://quay.io/repository/centos7/php-72-centos7)
-* CentOS 7 [php-73](https://quay.io/repository/centos7/php-73-centos7)
-* CentOS 7 [php-74](https://quay.io/repository/centos7/php-74-centos7)
 * CentOS Stream 9 [php-74](https://quay.io/repository/sclorg/php-74-c9s)
 * Fedora [php-80](https://quay.io/repository/fedora/php-80)
 * Fedora [php-81](https://quay.io/repository/fedora/php-81)
@@ -37,12 +34,8 @@ PHP versions currently supported are:
 * [php-8.2](8.2)
 
 RHEL versions currently supported are:
-* RHEL7
 * RHEL8
 * RHEL9
-
-CentOS versions currently supported are:
-* CentOS7
 
 CenOS Stream versions currently supported are:
 * CentOS Stream 9
@@ -72,12 +65,12 @@ To build a PHP image, choose either the CentOS or RHEL based image:
     ```
     $ git clone --recursive https://github.com/sclorg/s2i-php-container.git
     $ cd s2i-php-container
-    $ make build TARGET=centos7 VERSIONS=7.3
+    $ make build TARGET=c9s VERSIONS=7.4
     ```
 
-Alternatively, you can pull the CentOS image from Docker Hub via:
+Alternatively, you can pull the CentOS Stream image from Docker Hub via:
 
-    $ podman pull centos7/php-73-centos7
+    $ podman pull registry.access.redhat.com/ubi8/php-74
 
 Note: while the installation steps are calling `podman`, you can replace any such calls by `docker` with the same arguments.
 
@@ -87,11 +80,11 @@ on all the supported versions of PHP.**
 
 Usage
 -----
-For information about usage of Dockerfile for PHP 7.4,
-see [usage documentation](7.4/README.md).
-
 For information about usage of Dockerfile for PHP 7.3,
 see [usage documentation](7.3/README.md).
+
+For information about usage of Dockerfile for PHP 7.4,
+see [usage documentation](7.4/README.md).
 
 For information about usage of Dockerfile for PHP 8.0,
 see [usage documentation](8.0/README.md).
@@ -121,11 +114,11 @@ Users can choose between testing a PHP test application based on a RHEL or CentO
     $ make test TARGET=rhel8 VERSIONS=7.4
     ```
 
-*  **CentOS based image**
+*  **CentOS Stream based image**
 
     ```
     $ cd s2i-php-container
-    $ make test TARGET=centos7 VERSIONS=7.3
+    $ make test TARGET=c9s VERSIONS=7.4
     ```
 
 **Notice: By omitting the `VERSIONS` parameter, the build/test action will be performed
@@ -136,11 +129,11 @@ Repository organization
 -----------------------
 * **`<php-version>`**
 
-    * **Dockerfile**
+    * **Dockerfile.c9s**
 
-        CentOS based Dockerfile.
+        CentOS Stream based Dockerfile.
 
-    * **Dockerfile.rhel7**
+    * **Dockerfile.rhel8**
 
         RHEL based Dockerfile. In order to perform build or test actions on this
         Dockerfile you need to run the action on properly subscribed RHEL machine.

--- a/imagestreams/imagestreams.yaml
+++ b/imagestreams/imagestreams.yaml
@@ -13,9 +13,6 @@
   - filename: php-centos.json
     latest: "8.0-ubi8"
     distros:
-      - name: UBI 7
-        app_versions: ["7.3"]
-
       - name: UBI 8
         app_versions: ["7.4", "8.0", "8.2"]
 
@@ -25,18 +22,11 @@
   - filename: php-rhel.json
     latest: "8.0-ubi8"
     distros:
-      - name: UBI 7
-        app_versions: ["7.3"]
-
       - name: UBI 8
         app_versions: ["7.4", "8.0", "8.2"]
 
       - name: UBI 9
         app_versions: ["8.0", "8.1", "8.2"]
-    custom_tags:
-      - name: "7.3"
-        distro: UBI 7
-        app_version: "7.3"
 
   - filename: php-rhel-aarch64.json
     latest: "8.0-ubi8"

--- a/imagestreams/php-centos.json
+++ b/imagestreams/php-centos.json
@@ -10,25 +10,6 @@
   "spec": {
     "tags": [
       {
-        "name": "7.3-ubi7",
-        "annotations": {
-          "openshift.io/display-name": "PHP 7.3 (UBI 7)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run PHP 7.3 applications on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/7.3/README.md.",
-          "iconClass": "icon-php",
-          "tags": "builder,php",
-          "version": "7.3",
-          "sampleRepo": "https://github.com/sclorg/cakephp-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.access.redhat.com/ubi7/php-73:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
         "name": "7.4-ubi8",
         "annotations": {
           "openshift.io/display-name": "PHP 7.4 (UBI 8)",

--- a/imagestreams/php-rhel.json
+++ b/imagestreams/php-rhel.json
@@ -10,25 +10,6 @@
   "spec": {
     "tags": [
       {
-        "name": "7.3-ubi7",
-        "annotations": {
-          "openshift.io/display-name": "PHP 7.3 (UBI 7)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run PHP 7.3 applications on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/7.3/README.md.",
-          "iconClass": "icon-php",
-          "tags": "builder,php",
-          "version": "7.3",
-          "sampleRepo": "https://github.com/sclorg/cakephp-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.redhat.io/ubi7/php-73:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
         "name": "7.4-ubi8",
         "annotations": {
           "openshift.io/display-name": "PHP 7.4 (UBI 8)",
@@ -137,25 +118,6 @@
         "from": {
           "kind": "DockerImage",
           "name": "registry.redhat.io/ubi9/php-82:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
-        "name": "7.3",
-        "annotations": {
-          "openshift.io/display-name": "PHP 7.3 (UBI 7)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run PHP 7.3 applications on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/7.3/README.md.",
-          "iconClass": "icon-php",
-          "tags": "builder,php",
-          "version": "7.3",
-          "sampleRepo": "https://github.com/sclorg/cakephp-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.redhat.io/ubi7/php-73:latest"
         },
         "referencePolicy": {
           "type": "Local"

--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -5,7 +5,7 @@
 # IMAGE_NAME specifies a name of the candidate image used for testing.
 # The image has to be available before this script is executed.
 # VERSION specifies the major version of the PHP runtime in format of X.Y
-# OS specifies RHEL version (e.g. OS=rhel7)
+# OS specifies RHEL version (e.g. OS=rhel8)
 #
 
 THISDIR=$(dirname ${BASH_SOURCE[0]})


### PR DESCRIPTION
This pull request deprecates building, testing PHP container in RHEL-7.

The pull request is separated to two commits:
1) Remove RHEL-7 from CI and disable building and testing.
2) Update README's so that RHEL-7 -> RHEL-8 and CentOS7 -> CentOS Stream 9
<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
