### PR TITLE
Move $HOME env variable outside web server's Document root

### DIFF
--- a/7.4/Dockerfile.rhel7
+++ b/7.4/Dockerfile.rhel7
@@ -66,7 +66,8 @@ ENV PHP_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/php/ \
     HTTPD_DATA_PATH=/var/www \
     HTTPD_DATA_ORIG_PATH=/opt/rh/httpd24/root/var/www \
     HTTPD_VAR_PATH=/opt/rh/httpd24/root/var \
-    SCL_ENABLED=rh-php74
+    SCL_ENABLED=rh-php74 \
+    HOME=/opt/app-root
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH
 COPY ./s2i/bin/ $STI_SCRIPTS_PATH

--- a/7.4/Dockerfile.rhel8
+++ b/7.4/Dockerfile.rhel8
@@ -65,7 +65,8 @@ ENV PHP_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/php/ \
     HTTPD_VAR_RUN=/var/run/httpd \
     HTTPD_DATA_PATH=/var/www \
     HTTPD_DATA_ORIG_PATH=/var/www \
-    HTTPD_VAR_PATH=/var
+    HTTPD_VAR_PATH=/var \
+    HOME=/opt/app-root
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH
 COPY ./s2i/bin/ $STI_SCRIPTS_PATH

--- a/8.0/Dockerfile.rhel8
+++ b/8.0/Dockerfile.rhel8
@@ -65,7 +65,8 @@ ENV PHP_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/php/ \
     HTTPD_VAR_RUN=/var/run/httpd \
     HTTPD_DATA_PATH=/var/www \
     HTTPD_DATA_ORIG_PATH=/var/www \
-    HTTPD_VAR_PATH=/var
+    HTTPD_VAR_PATH=/var \
+    HOME=/opt/app-root
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH
 COPY ./s2i/bin/ $STI_SCRIPTS_PATH

--- a/8.0/Dockerfile.rhel9
+++ b/8.0/Dockerfile.rhel9
@@ -70,7 +70,8 @@ ENV PHP_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/php/ \
     HTTPD_VAR_RUN=/var/run/httpd \
     HTTPD_DATA_PATH=/var/www \
     HTTPD_DATA_ORIG_PATH=/var/www \
-    HTTPD_VAR_PATH=/var
+    HTTPD_VAR_PATH=/var \
+    HOME=/opt/app-root
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH
 COPY ./s2i/bin/ $STI_SCRIPTS_PATH

--- a/8.1/Dockerfile.fedora
+++ b/8.1/Dockerfile.fedora
@@ -64,7 +64,8 @@ ENV PHP_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/php/ \
     HTTPD_VAR_RUN=/var/run/httpd \
     HTTPD_DATA_PATH=/var/www \
     HTTPD_DATA_ORIG_PATH=/var/www \
-    HTTPD_VAR_PATH=/var
+    HTTPD_VAR_PATH=/var \
+    HOME=/opt/app-root
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH
 COPY ./s2i/bin/ $STI_SCRIPTS_PATH

--- a/8.1/Dockerfile.rhel9
+++ b/8.1/Dockerfile.rhel9
@@ -71,7 +71,8 @@ ENV PHP_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/php/ \
     HTTPD_VAR_RUN=/var/run/httpd \
     HTTPD_DATA_PATH=/var/www \
     HTTPD_DATA_ORIG_PATH=/var/www \
-    HTTPD_VAR_PATH=/var
+    HTTPD_VAR_PATH=/var \
+    HOME=/opt/app-root
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH
 COPY ./s2i/bin/ $STI_SCRIPTS_PATH

--- a/8.2/Dockerfile.fedora
+++ b/8.2/Dockerfile.fedora
@@ -64,7 +64,8 @@ ENV PHP_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/php/ \
     HTTPD_VAR_RUN=/var/run/httpd \
     HTTPD_DATA_PATH=/var/www \
     HTTPD_DATA_ORIG_PATH=/var/www \
-    HTTPD_VAR_PATH=/var
+    HTTPD_VAR_PATH=/var \
+    HOME=/opt/app-root
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH
 COPY ./s2i/bin/ $STI_SCRIPTS_PATH

--- a/8.2/Dockerfile.rhel8
+++ b/8.2/Dockerfile.rhel8
@@ -65,7 +65,8 @@ ENV PHP_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/php/ \
     HTTPD_VAR_RUN=/var/run/httpd \
     HTTPD_DATA_PATH=/var/www \
     HTTPD_DATA_ORIG_PATH=/var/www \
-    HTTPD_VAR_PATH=/var
+    HTTPD_VAR_PATH=/var \
+    HOME=/opt/app-root
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH
 COPY ./s2i/bin/ $STI_SCRIPTS_PATH

--- a/8.2/Dockerfile.rhel9
+++ b/8.2/Dockerfile.rhel9
@@ -71,7 +71,8 @@ ENV PHP_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/php/ \
     HTTPD_VAR_RUN=/var/run/httpd \
     HTTPD_DATA_PATH=/var/www \
     HTTPD_DATA_ORIG_PATH=/var/www \
-    HTTPD_VAR_PATH=/var
+    HTTPD_VAR_PATH=/var \
+    HOME=/opt/app-root
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH
 COPY ./s2i/bin/ $STI_SCRIPTS_PATH

--- a/test/run
+++ b/test/run
@@ -171,7 +171,7 @@ test_home_not_in_webroot() {
   test_connection ${test_port}
 
   info "Testing whether \$HOME points to web server Document root"
-  homef=$(docker exec -it $(cat ${cid_file}) /bin/bash -c "echo \$HOME")
+  local homef=$(docker exec -it $(cat ${cid_file}) /bin/bash -c "echo \$HOME")
   ct_check_testcase_result $?
   if [ "${homef}" = "${homef##/opt/app-root/src}" ]; then
     echo "Home folder not set to Document root"

--- a/test/run
+++ b/test/run
@@ -19,6 +19,7 @@ test_ssl
 test_ssl_own_cert
 ct_npm_works
 test_build_from_dockerfile
+test_home_not_in_webroot
 "
 
 TEST_CLEAR_ENV="\
@@ -160,6 +161,25 @@ test_config_writeable() {
 
   info "Checking if configuration is writeable"
   docker run --rm "${IMAGE_NAME}" /bin/bash -c "${run_cmd}"
+}
+
+test_home_not_in_webroot() {
+  cid_file=$CID_FILE_DIR/$(mktemp -u -p . --suffix .cid)
+  docker run -d --cidfile=${cid_file} ${IMAGE_NAME}-testapp
+
+  # Wait for container to initialize fully
+  test_connection ${test_port}
+
+  info "Testing whether \$HOME points to web server Document root"
+  homef=$(docker exec -it $(cat ${cid_file}) /bin/bash -c "echo \$HOME")
+  ct_check_testcase_result $?
+  if [ "${homef}" = "${homef##/opt/app-root/src}" ]; then
+    echo "Home folder not set to Document root"
+    return 0
+  fi
+
+  info "Home folder set to Document root"
+  return 1
 }
 
 test_clear_env_setup() {


### PR DESCRIPTION
Overwrite $HOME env variable for all supported versions. Default $HOME is directed inside the web server's Document root, which means that applications that save potentially private data to $HOME (e.g. bash's histfile) will save them into a folder accessible outside the container via the web server. This means there is a possibility of leaking the data.

This does not occur in all cases, namely bash won't create a histfile at all, when user sets a different user via `--user=` argument in `podman run` command, as in that case bash doesn't have a permission to write into the $HOME.

Fixes: #255 


<!-- issue-commentator = {"comment-id":"2379094642"} -->





















































































































<!-- testing-farm = {"lock":"false","comment-id":"2454789627","data":[{"id":"1d54a9ef-bc00-44ba-9916-3bfb5e8e09f5","name":"RHEL9 - PyTest - OpenShift 4 - 8.1","status":"complete","outcome":"failed","runTime":764.697058,"created":"2024-11-04T13:45:44.371848","updated":"2024-11-04T13:45:44.371856","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1d54a9ef-bc00-44ba-9916-3bfb5e8e09f5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1d54a9ef-bc00-44ba-9916-3bfb5e8e09f5/pipeline.log\">pipeline</a>"]},{"id":"d10ef17c-781f-4771-a317-b2ae901dbb9e","name":"RHEL9 - PyTest - OpenShift 4 - 8.0","status":"complete","outcome":"failed","runTime":793.73607,"created":"2024-11-04T13:45:23.545821","updated":"2024-11-04T13:45:23.545828","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d10ef17c-781f-4771-a317-b2ae901dbb9e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d10ef17c-781f-4771-a317-b2ae901dbb9e/pipeline.log\">pipeline</a>"]},{"id":"3131357d-ccd2-46b3-9a70-fef7e6514c02","name":"RHEL8 - PyTest - OpenShift 4 - 7.4","status":"complete","outcome":"failed","runTime":969.81988,"created":"2024-11-04T13:45:11.807810","updated":"2024-11-04T13:45:11.807816","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3131357d-ccd2-46b3-9a70-fef7e6514c02\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3131357d-ccd2-46b3-9a70-fef7e6514c02/pipeline.log\">pipeline</a>"]},{"id":"b5821b39-ad4a-4c28-87f4-da4e90ad1d9e","name":"RHEL8 - PyTest - OpenShift 4 - 8.0","status":"complete","outcome":"failed","runTime":974.838723,"created":"2024-11-04T13:45:16.359056","updated":"2024-11-04T13:45:16.359066","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b5821b39-ad4a-4c28-87f4-da4e90ad1d9e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b5821b39-ad4a-4c28-87f4-da4e90ad1d9e/pipeline.log\">pipeline</a>"]},{"id":"3ce961d0-644f-41d7-9993-d9954b8dc3cb","name":"RHEL8 - PyTest - OpenShift 4 - 8.2","status":"complete","outcome":"failed","runTime":949.012719,"created":"2024-11-04T13:47:18.428333","updated":"2024-11-04T13:47:18.428340","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3ce961d0-644f-41d7-9993-d9954b8dc3cb\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3ce961d0-644f-41d7-9993-d9954b8dc3cb/pipeline.log\">pipeline</a>"]},{"id":"cd766ed0-d604-4fdd-bc15-85eb27b6f61c","name":"RHEL9 - 8.0","status":"complete","outcome":"passed","runTime":1362.32758,"created":"2024-11-04T13:44:47.395839","updated":"2024-11-04T13:44:47.395847","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/cd766ed0-d604-4fdd-bc15-85eb27b6f61c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/cd766ed0-d604-4fdd-bc15-85eb27b6f61c/pipeline.log\">pipeline</a>"]},{"id":"6f3ba758-e650-46c2-b00f-3403e8815013","name":"RHEL9 - 8.2","status":"complete","outcome":"passed","runTime":1439.526604,"created":"2024-11-04T13:45:01.389778","updated":"2024-11-04T13:45:01.389787","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6f3ba758-e650-46c2-b00f-3403e8815013\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6f3ba758-e650-46c2-b00f-3403e8815013/pipeline.log\">pipeline</a>"]},{"id":"58a5dcd3-a467-4958-a451-5a6f6b5f6251","name":"RHEL9 - 8.1","status":"complete","outcome":"passed","runTime":1456.43601,"created":"2024-11-04T13:44:49.333762","updated":"2024-11-04T13:44:49.333769","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/58a5dcd3-a467-4958-a451-5a6f6b5f6251\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/58a5dcd3-a467-4958-a451-5a6f6b5f6251/pipeline.log\">pipeline</a>"]},{"id":"758f21c1-8605-437c-81df-cc3d8256d78e","name":"RHEL9 - PyTest - OpenShift 4 - 8.2","status":"complete","outcome":"failed","runTime":947.959315,"created":"2024-11-04T13:55:04.667741","updated":"2024-11-04T13:55:04.667751","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/758f21c1-8605-437c-81df-cc3d8256d78e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/758f21c1-8605-437c-81df-cc3d8256d78e/pipeline.log\">pipeline</a>"]},{"id":"929867f9-7d32-4ec5-be96-b1ee57aefc89","name":"RHEL8 - 7.4","status":"complete","outcome":"passed","runTime":1581.166594,"created":"2024-11-04T13:44:40.211615","updated":"2024-11-04T13:44:40.211623","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/929867f9-7d32-4ec5-be96-b1ee57aefc89\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/929867f9-7d32-4ec5-be96-b1ee57aefc89/pipeline.log\">pipeline</a>"]},{"id":"88c2575e-8fb2-405a-8a96-7a62e3019c40","name":"RHEL8 - 8.2","status":"complete","outcome":"passed","runTime":1609.511454,"created":"2024-11-04T13:45:00.577184","updated":"2024-11-04T13:45:00.577191","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/88c2575e-8fb2-405a-8a96-7a62e3019c40\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/88c2575e-8fb2-405a-8a96-7a62e3019c40/pipeline.log\">pipeline</a>"]},{"id":"08c782ec-7959-417d-b693-f70e4deb6379","name":"RHEL8 - 8.0","status":"complete","outcome":"passed","runTime":1636.281896,"created":"2024-11-04T13:44:50.429512","updated":"2024-11-04T13:44:50.429522","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/08c782ec-7959-417d-b693-f70e4deb6379\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/08c782ec-7959-417d-b693-f70e4deb6379/pipeline.log\">pipeline</a>"]},{"id":"d9070154-df6a-4859-8ec1-da5cffb3a57e","name":"RHEL9 - OpenShift 4 - 8.1","status":"complete","outcome":"passed","runTime":1172.250869,"created":"2024-11-04T13:59:53.865429","updated":"2024-11-04T13:59:53.865438","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d9070154-df6a-4859-8ec1-da5cffb3a57e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d9070154-df6a-4859-8ec1-da5cffb3a57e/pipeline.log\">pipeline</a>"]},{"id":"c45f3afb-0ff1-4191-82e5-9b63aec4a655","name":"RHEL8 - OpenShift 4 - 7.4","status":"complete","outcome":"passed","runTime":1342.255289,"created":"2024-11-04T13:59:34.819550","updated":"2024-11-04T13:59:34.819559","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c45f3afb-0ff1-4191-82e5-9b63aec4a655\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c45f3afb-0ff1-4191-82e5-9b63aec4a655/pipeline.log\">pipeline</a>"]},{"id":"5b3500dc-acc7-4084-98a5-7ae5ed4b9182","name":"RHEL9 - OpenShift 4 - 8.0","status":"complete","outcome":"passed","runTime":1332.536781,"created":"2024-11-04T13:59:39.379513","updated":"2024-11-04T13:59:39.379520","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5b3500dc-acc7-4084-98a5-7ae5ed4b9182\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5b3500dc-acc7-4084-98a5-7ae5ed4b9182/pipeline.log\">pipeline</a>"]},{"id":"9f8e007a-e9fe-4afc-b6b0-f215fbabff45","name":"RHEL8 - OpenShift 4 - 8.0","status":"complete","outcome":"passed","runTime":1336.202405,"created":"2024-11-04T13:59:37.332231","updated":"2024-11-04T13:59:37.332238","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9f8e007a-e9fe-4afc-b6b0-f215fbabff45\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9f8e007a-e9fe-4afc-b6b0-f215fbabff45/pipeline.log\">pipeline</a>"]},{"id":"ebe6edf4-5fd1-4347-ad0c-85cccc1963fd","name":"RHEL9 - OpenShift 4 - 8.2","status":"complete","outcome":"passed","runTime":1258.970946,"created":"2024-11-04T14:01:18.084917","updated":"2024-11-04T14:01:18.084926","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ebe6edf4-5fd1-4347-ad0c-85cccc1963fd\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ebe6edf4-5fd1-4347-ad0c-85cccc1963fd/pipeline.log\">pipeline</a>"]},{"id":"26e88fb6-8237-491e-9561-66ad9df6d1a0","name":"RHEL8 - OpenShift 4 - 8.2","status":"complete","outcome":"passed","runTime":1333.541982,"created":"2024-11-04T14:00:16.186661","updated":"2024-11-04T14:00:16.186669","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/26e88fb6-8237-491e-9561-66ad9df6d1a0\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/26e88fb6-8237-491e-9561-66ad9df6d1a0/pipeline.log\">pipeline</a>"]},{"id":"0f85e6e7-d6b6-4191-a5d2-8c2afed09d08","name":"Fedora - 8.2","status":"complete","outcome":"passed","runTime":2544.15573,"created":"2024-11-04T13:45:00.520950","updated":"2024-11-04T13:45:00.520958","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/0f85e6e7-d6b6-4191-a5d2-8c2afed09d08\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/0f85e6e7-d6b6-4191-a5d2-8c2afed09d08/pipeline.log\">pipeline</a>"]},{"id":"249aa08c-ed09-4b74-993f-e8428003f6b1","name":"Fedora - 8.1","runTime":2648.484659,"created":"2024-11-04T13:44:50.541420","updated":"2024-11-04T13:44:50.541428","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.dev.testing-farm.io/249aa08c-ed09-4b74-993f-e8428003f6b1\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/249aa08c-ed09-4b74-993f-e8428003f6b1/pipeline.log\">pipeline</a>"]}]} -->