### PR TITLE
Support testing s2i-php-container on CentOS Stream  10

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         version: [ "7.3", "7.4", "8.0", "8.1", "8.2" ]
-        os_test: [ "fedora", "rhel8", "rhel9", "c9s"]
+        os_test: [ "fedora", "rhel8", "rhel9", "c9s", "c10s"]
         test_case: [ "container" ]
 
     if: |


### PR DESCRIPTION
This pull request allows testing s2i-php-container on CentOS Stream 10 host.

See similar PR: 
https://github.com/sclorg/httpd-container/pull/223

https://github.com/sclorg/mariadb-container/pull/251
