### PR TITLE
Allow testing PHP 8.3 version

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [ "7.3", "7.4", "8.0", "8.1", "8.2" ]
+        version: [ "7.3", "7.4", "8.0", "8.1", "8.2", "8.3" ]
         os_test: [ "fedora", "rhel8", "rhel9", "c9s", "c10s"]
         test_case: [ "container" ]
 


### PR DESCRIPTION
Starting tests is not needed. GA is only fixed.
