### PR TITLE
Add support for building and pushing php-83 image to quay.io/sclorg

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -46,6 +46,14 @@ jobs:
             tag: "8.3"
             image_name: "php-83"
 
+          - dockerfile: "8.3/Dockerfile.c10s"
+            docker_context: "8.3"
+            registry_namespace: "sclorg"
+            quayio_username: "QUAY_IMAGE_FEDORA_BUILDER_USERNAME"
+            quayio_token: "QUAY_IMAGE_FEDORA_BUILDER_TOKEN"
+            tag: "c10s"
+            image_name: "php-83-c10s"
+
     steps:
       - name: Build and push to quay.io registry
         uses: sclorg/build-and-push-action@v4


### PR DESCRIPTION
Add support for building and pushing php-83 image to quay.io/sclorg organization



















































<!-- issue-commentator = {"comment-id":"2379095066"} -->











































































<!-- testing-farm = {"lock":"false","comment-id":"2379073297","data":[{"id":"4a4f59f2-c6fa-4438-a9df-4efda601ead8","name":"RHEL9 - 8.0","status":"complete","outcome":"passed","runTime":1406.849261,"created":"2024-09-27T11:13:36.936426","updated":"2024-09-27T11:13:36.936433","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4a4f59f2-c6fa-4438-a9df-4efda601ead8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4a4f59f2-c6fa-4438-a9df-4efda601ead8/pipeline.log\">pipeline</a>"]},{"id":"ebaf04be-1126-40b7-a29e-41ae2a1649fa","name":"RHEL8 - 7.4","status":"complete","outcome":"passed","runTime":1602.6433,"created":"2024-09-27T11:13:14.980556","updated":"2024-09-27T11:13:14.980565","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ebaf04be-1126-40b7-a29e-41ae2a1649fa\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ebaf04be-1126-40b7-a29e-41ae2a1649fa/pipeline.log\">pipeline</a>"]},{"id":"0340908e-545c-4bfa-93c5-b76a48802c65","name":"Fedora - 8.1","status":"complete","outcome":"passed","runTime":1084.513907,"created":"2024-09-27T11:21:37.500689","updated":"2024-09-27T11:21:37.500698","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/0340908e-545c-4bfa-93c5-b76a48802c65\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/0340908e-545c-4bfa-93c5-b76a48802c65/pipeline.log\">pipeline</a>"]},{"id":"cd22aed7-c0e1-4099-aae9-01640721f46d","name":"Fedora - 8.2","status":"complete","outcome":"passed","runTime":1063.485169,"created":"2024-09-27T11:23:35.445848","updated":"2024-09-27T11:23:35.445860","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/cd22aed7-c0e1-4099-aae9-01640721f46d\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/cd22aed7-c0e1-4099-aae9-01640721f46d/pipeline.log\">pipeline</a>"]},{"id":"d6258720-6b25-41b8-a42c-b7d8f116387a","name":"CentOS Stream 10 - 8.3","status":"complete","outcome":"passed","runTime":1201.758383,"created":"2024-09-27T11:23:56.817800","updated":"2024-09-27T11:23:56.817807","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/d6258720-6b25-41b8-a42c-b7d8f116387a\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/d6258720-6b25-41b8-a42c-b7d8f116387a/pipeline.log\">pipeline</a>"]},{"id":"caa20030-6991-4a2c-b321-cfe5e5eb3f30","name":"RHEL9 - 8.1","status":"complete","outcome":"passed","runTime":1323.300515,"created":"2024-09-27T11:23:24.340098","updated":"2024-09-27T11:23:24.340106","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/caa20030-6991-4a2c-b321-cfe5e5eb3f30\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/caa20030-6991-4a2c-b321-cfe5e5eb3f30/pipeline.log\">pipeline</a>"]},{"id":"01bdc90c-b632-4be9-bf1f-38afd59b1f01","name":"RHEL9 - 8.2","status":"complete","outcome":"passed","runTime":1347.945146,"created":"2024-09-27T11:23:59.384719","updated":"2024-09-27T11:23:59.384726","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/01bdc90c-b632-4be9-bf1f-38afd59b1f01\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/01bdc90c-b632-4be9-bf1f-38afd59b1f01/pipeline.log\">pipeline</a>"]},{"id":"d0c138f7-ba29-4622-bb6b-ae55c250df80","name":"RHEL8 - 8.2","status":"complete","outcome":"passed","runTime":1494.256238,"created":"2024-09-27T11:23:49.580226","updated":"2024-09-27T11:23:49.580233","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d0c138f7-ba29-4622-bb6b-ae55c250df80\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d0c138f7-ba29-4622-bb6b-ae55c250df80/pipeline.log\">pipeline</a>"]},{"id":"c360f5c6-fe81-4821-aa24-53e6dca70ff6","name":"Fedora - 8.3","status":"complete","outcome":"passed","runTime":1048.981335,"created":"2024-09-27T11:36:34.515759","updated":"2024-09-27T11:36:34.515768","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/c360f5c6-fe81-4821-aa24-53e6dca70ff6\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/c360f5c6-fe81-4821-aa24-53e6dca70ff6/pipeline.log\">pipeline</a>"]},{"id":"89561454-322c-458c-83ca-70e92ad37ca7","name":"RHEL9 - OpenShift 4 - 8.0","status":"complete","outcome":"passed","runTime":1100.572344,"created":"2024-09-27T11:37:54.307518","updated":"2024-09-27T11:37:54.307525","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/89561454-322c-458c-83ca-70e92ad37ca7\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/89561454-322c-458c-83ca-70e92ad37ca7/pipeline.log\">pipeline</a>"]},{"id":"f2581463-cf48-4ed1-a3bb-a16b1fb5741d","name":"RHEL8 - OpenShift 4 - 7.4","status":"complete","outcome":"passed","runTime":1226.982673,"created":"2024-09-27T11:38:18.238758","updated":"2024-09-27T11:38:18.238767","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f2581463-cf48-4ed1-a3bb-a16b1fb5741d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f2581463-cf48-4ed1-a3bb-a16b1fb5741d/pipeline.log\">pipeline</a>"]},{"id":"97f73a40-78f2-4a44-b92f-e1eb25167bff","name":"RHEL8 - OpenShift 4 - 8.0","status":"complete","outcome":"passed","runTime":1325.225471,"created":"2024-09-27T11:37:51.012429","updated":"2024-09-27T11:37:51.012439","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/97f73a40-78f2-4a44-b92f-e1eb25167bff\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/97f73a40-78f2-4a44-b92f-e1eb25167bff/pipeline.log\">pipeline</a>"]},{"id":"f6308508-5c3b-4bd2-ab0a-d2075ab7afbd","name":"RHEL9 - OpenShift 4 - 8.1","status":"complete","outcome":"passed","runTime":1327.086506,"created":"2024-09-27T11:40:26.931470","updated":"2024-09-27T11:40:26.931479","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f6308508-5c3b-4bd2-ab0a-d2075ab7afbd\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f6308508-5c3b-4bd2-ab0a-d2075ab7afbd/pipeline.log\">pipeline</a>"]},{"id":"85e1c382-243c-4687-bb0b-f09afe94591c","name":"RHEL9 - OpenShift 4 - 8.2","status":"complete","outcome":"passed","runTime":1250.631726,"created":"2024-09-27T11:42:01.052033","updated":"2024-09-27T11:42:01.052043","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/85e1c382-243c-4687-bb0b-f09afe94591c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/85e1c382-243c-4687-bb0b-f09afe94591c/pipeline.log\">pipeline</a>"]},{"id":"715861d9-e676-404b-983b-7f2178298806","name":"RHEL8 - OpenShift 4 - 8.2","status":"complete","outcome":"passed","runTime":1361.440117,"created":"2024-09-27T11:40:26.631688","updated":"2024-09-27T11:40:26.631700","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/715861d9-e676-404b-983b-7f2178298806\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/715861d9-e676-404b-983b-7f2178298806/pipeline.log\">pipeline</a>"]},{"id":"1f60fac4-221f-4c63-9d3d-46c90f7784c4","name":"RHEL8 - PyTest - OpenShift 4 - 7.4","status":"complete","outcome":"passed","runTime":1590.690085,"created":"2024-09-27T11:43:29.908928","updated":"2024-09-27T11:43:29.908937","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1f60fac4-221f-4c63-9d3d-46c90f7784c4\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1f60fac4-221f-4c63-9d3d-46c90f7784c4/pipeline.log\">pipeline</a>"]},{"id":"1a93b997-595d-4e51-8eb4-d6f45cd0a0db","name":"RHEL8 - PyTest - OpenShift 4 - 8.0","status":"complete","outcome":"passed","runTime":1699.783451,"created":"2024-09-27T11:44:32.809215","updated":"2024-09-27T11:44:32.809221","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1a93b997-595d-4e51-8eb4-d6f45cd0a0db\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1a93b997-595d-4e51-8eb4-d6f45cd0a0db/pipeline.log\">pipeline</a>"]},{"id":"98e9816a-30c3-46f8-8072-93ad946772c5","name":"RHEL9 - PyTest - OpenShift 4 - 8.2","status":"complete","outcome":"passed","runTime":1549.533314,"created":"2024-09-27T11:47:04.573153","updated":"2024-09-27T11:47:04.573162","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/98e9816a-30c3-46f8-8072-93ad946772c5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/98e9816a-30c3-46f8-8072-93ad946772c5/pipeline.log\">pipeline</a>"]},{"id":"67ee4b1d-10d6-4cfb-a88e-3763a7fc32b1","name":"RHEL9 - PyTest - OpenShift 4 - 8.0","status":"complete","outcome":"passed","runTime":1668.960478,"created":"2024-09-27T11:45:50.977920","updated":"2024-09-27T11:45:50.977929","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/67ee4b1d-10d6-4cfb-a88e-3763a7fc32b1\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/67ee4b1d-10d6-4cfb-a88e-3763a7fc32b1/pipeline.log\">pipeline</a>"]},{"id":"aa2ec85a-cc9f-4f78-a9a3-a5e953921e82","name":"RHEL8 - PyTest - OpenShift 4 - 8.2","status":"complete","outcome":"passed","runTime":1648.288986,"created":"2024-09-27T11:47:04.502202","updated":"2024-09-27T11:47:04.502209","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/aa2ec85a-cc9f-4f78-a9a3-a5e953921e82\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/aa2ec85a-cc9f-4f78-a9a3-a5e953921e82/pipeline.log\">pipeline</a>"]},{"id":"5defa70d-b6a7-4439-ad48-88dddf01a47f","name":"RHEL8 - 8.0","runTime":1693.738539,"created":"2024-09-30T07:35:19.611897","updated":"2024-09-30T07:35:19.611910","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5defa70d-b6a7-4439-ad48-88dddf01a47f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5defa70d-b6a7-4439-ad48-88dddf01a47f/pipeline.log\">pipeline</a>"]}]} -->