### PR TITLE
Building and testing container on RHEL10 host

### DIFF
--- a/8.3/Dockerfile.rhel10
+++ b/8.3/Dockerfile.rhel10
@@ -1,0 +1,94 @@
+FROM ubi10/s2i-base
+
+# This image provides an Apache+PHP environment for running PHP
+# applications.
+
+EXPOSE 8080
+EXPOSE 8443
+
+# Description
+# This image provides an Apache 2.4 + PHP 8.3 environment for running PHP applications.
+# Exposed ports:
+# * 8080 - alternative port for http
+
+ENV PHP_VERSION=8.3 \
+    PHP_VER_SHORT=83 \
+    NAME=php
+
+ENV SUMMARY="Platform for building and running PHP $PHP_VERSION applications" \
+    DESCRIPTION="PHP $PHP_VERSION available as container is a base platform for \
+building and running various PHP $PHP_VERSION applications and frameworks. \
+PHP is an HTML-embedded scripting language. PHP attempts to make it easy for developers \
+to write dynamically generated web pages. PHP also offers built-in database integration \
+for several commercial and non-commercial database management systems, so writing \
+a database-enabled webpage with PHP is fairly simple. The most common use of PHP coding \
+is probably as a replacement for CGI scripts."
+
+LABEL summary="${SUMMARY}" \
+      description="${DESCRIPTION}" \
+      io.k8s.description="${DESCRIPTION}" \
+      io.k8s.display-name="Apache 2.4 with PHP ${PHP_VERSION}" \
+      io.openshift.expose-services="8080:http" \
+      io.openshift.tags="builder,${NAME},${NAME}${PHP_VER_SHORT},${NAME}-${PHP_VER_SHORT}" \
+      io.openshift.s2i.scripts-url="image:///usr/libexec/s2i" \
+      io.s2i.scripts-url="image:///usr/libexec/s2i" \
+      name="ubi10/${NAME}-${PHP_VER_SHORT}" \
+      com.redhat.component="${NAME}-${PHP_VER_SHORT}-container" \
+      version="1" \
+      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI" \
+      help="For more information visit https://github.com/sclorg/s2i-${NAME}-container" \
+      usage="s2i build https://github.com/sclorg/s2i-php-container.git --context-dir=${PHP_VERSION}/test/test-app ubi10/${NAME}-${PHP_VER_SHORT} sample-server" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
+
+# Install Apache httpd and PHP
+ARG INSTALL_PKGS="php php-fpm php-mysqlnd php-pgsql php-bcmath \
+                  php-gd php-intl php-ldap php-mbstring php-pdo \
+                  php-process php-soap php-opcache php-xml \
+                  php-gmp php-pecl-apcu php-pecl-zip mod_ssl hostname"
+
+# This needs to be added for downloading packages
+RUN curl -fL -o /etc/pki/ca-trust/source/anchors/2022-IT-Root-CA.pem https://certs.corp.redhat.com/certs/2022-IT-Root-CA.pem
+RUN update-ca-trust extract
+
+RUN dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    dnf reinstall -y tzdata && \
+    rpm -V $INSTALL_PKGS && \
+    php -v | grep -qe "v$PHP_VERSION\." && echo "Found VERSION $PHP_VERSION" && \
+    dnf -y clean all --enablerepo='*'
+
+# Remove the certs
+RUN rm /etc/pki/ca-trust/source/anchors/2022-IT-Root-CA.pem
+RUN update-ca-trust
+
+ENV PHP_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/php/ \
+    APP_DATA=${APP_ROOT}/src \
+    PHP_DEFAULT_INCLUDE_PATH=/usr/share/pear \
+    PHP_SYSCONF_PATH=/etc \
+    PHP_HTTPD_CONF_FILE=php.conf \
+    PHP_FPM_CONF_D_PATH=/etc/php-fpm.d \
+    PHP_FPM_CONF_FILE=www.conf \
+    PHP_FPM_RUN_DIR=/run/php-fpm \
+    PHP_MAIN_FPM_CONF_FILE=/etc/php-fpm.conf \
+    PHP_FPM_LOG_PATH=/var/log/php-fpm \
+    HTTPD_CONFIGURATION_PATH=${APP_ROOT}/etc/conf.d \
+    HTTPD_MAIN_CONF_PATH=/etc/httpd/conf \
+    HTTPD_MAIN_CONF_D_PATH=/etc/httpd/conf.d \
+    HTTPD_MODULES_CONF_D_PATH=/etc/httpd/conf.modules.d \
+    HTTPD_VAR_RUN=/var/run/httpd \
+    HTTPD_DATA_PATH=/var/www \
+    HTTPD_DATA_ORIG_PATH=/var/www \
+    HTTPD_VAR_PATH=/var
+
+# Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH
+COPY ./s2i/bin/ $STI_SCRIPTS_PATH
+
+# Copy extra files to the image.
+COPY ./root/ /
+
+# Reset permissions of filesystem to default values
+RUN /usr/libexec/container-setup && rpm-file-permissions
+
+USER 1001
+
+# Set the default CMD to print the usage of the language image
+CMD $STI_SCRIPTS_PATH/usage

--- a/8.3/Dockerfile.rhel10
+++ b/8.3/Dockerfile.rhel10
@@ -41,19 +41,23 @@ LABEL summary="${SUMMARY}" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 # Install Apache httpd and PHP
-ARG INSTALL_PKGS="php php-fpm php-mysqlnd php-pgsql php-bcmath \
+ARG INSTALL_PKGS="php php-fpm mod_ssl hostname"
+ARG INSTALL_EXTS="php-json php-mysqli php-pgsql php-bcmath \
                   php-gd php-intl php-ldap php-mbstring php-pdo \
                   php-process php-soap php-opcache php-xml \
-                  php-gmp php-pecl-apcu php-pecl-zip mod_ssl hostname"
+                  php-gmp php-apcu php-zip php-redis"
 
 # This needs to be added for downloading packages
 RUN curl -fL -o /etc/pki/ca-trust/source/anchors/2022-IT-Root-CA.pem https://certs.corp.redhat.com/certs/2022-IT-Root-CA.pem
 RUN update-ca-trust extract
 
-RUN dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+RUN dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS $INSTALL_EXTS && \
     dnf reinstall -y tzdata && \
     rpm -V $INSTALL_PKGS && \
-    php -v | grep -qe "v$PHP_VERSION\." && echo "Found VERSION $PHP_VERSION" && \
+    php -v | grep -qe "v$PHP_VERSION\." && \
+        echo "Found VERSION $PHP_VERSION" && \
+    for ext in $(echo $INSTALL_EXTS | sed s/php-//g) ; do php -m | grep -qi "$ext\$"; done && \
+        echo "Found requested extensions" && \
     dnf -y clean all --enablerepo='*'
 
 # Remove the certs

--- a/8.3/README.md
+++ b/8.3/README.md
@@ -323,6 +323,7 @@ See also
 Dockerfile and other sources are available on https://github.com/sclorg/s2i-php-container.
 In that repository you also can find another versions of Python environment Dockerfiles.
 Dockerfile for RHEL8 is called `Dockerfile.rhel8`, Dockerfile for RHEL9 is called `Dockerfile.rhel9`,
+Dockerfile for RHEL9 is called `Dockerfile.rhel10`,
 Dockerfile for CentOS Stream 10 is called `Dockerfile.c10s`,and the Fedora Dockerfile is called Dockerfile.fedora.
 
 Security Implications

--- a/8.3/root/usr/libexec/container-setup
+++ b/8.3/root/usr/libexec/container-setup
@@ -26,16 +26,14 @@ else
   rm -f /opt/app-root/etc/scl_enable
 fi
 
-if head "/etc/redhat-release" | grep -q -e "^Red Hat Enterprise Linux release 8" -e "^Red Hat Enterprise Linux release 9" -e "Fedora" -e "^CentOS Stream release 9" -e "^CentOS Stream release 10"; then
-    /usr/libexec/httpd-ssl-gencerts
-fi
+/usr/libexec/httpd-ssl-gencerts
 
 mkdir -p ${HTTPD_CONFIGURATION_PATH}
 chmod -R a+rwx ${HTTPD_MAIN_CONF_PATH}
 chmod -R a+rwx ${HTTPD_MAIN_CONF_D_PATH}
 chmod -R ug+r   /etc/pki/tls/certs/localhost.crt
-chmod -R ug+r   /etc/pki/tls/private/localhost.key
 chown -R 1001:0 /etc/pki/tls/certs/localhost.crt
+chmod -R ug+r   /etc/pki/tls/private/localhost.key
 chown -R 1001:0 /etc/pki/tls/private/localhost.key
 mkdir -p ${APP_ROOT}/etc
 chmod -R a+rwx ${APP_ROOT}/etc
@@ -45,16 +43,12 @@ mkdir -p /tmp/sessions
 chmod -R a+rwx /tmp/sessions
 chown -R 1001:0 /tmp/sessions
 chown -R 1001:0 ${HTTPD_DATA_PATH}
-if [ "$PLATFORM" == "el7" ]; then
-  # Only run for el7 as this essentially becomes "chmod -R /etc" outside of SCL-based images
-  chmod -R a+rwx "${PHP_SYSCONF_PATH}"
-else
-  chmod a+rwx "${PHP_SYSCONF_PATH}/php.ini"
-  chmod -R a+rwx "${PHP_SYSCONF_PATH}/php.d"
-  chmod -R a+rwx "${PHP_SYSCONF_PATH}/php-fpm.d"
-fi
 
-if [ "x$PLATFORM" == "xel9" ] || [ "x$PLATFORM" == "xel10" ]  || [ "x$PLATFORM" == "xfedora" ]; then
+chmod a+rwx "${PHP_SYSCONF_PATH}/php.ini"
+chmod -R a+rwx "${PHP_SYSCONF_PATH}/php.d"
+chmod -R a+rwx "${PHP_SYSCONF_PATH}/php-fpm.d"
+
+if [ "x$PLATFORM" == "xel10" ] || [ "x$PLATFORM" == "xel9" ]  || [ "x$PLATFORM" == "xfedora" ]; then
   if [ -v PHP_FPM_RUN_DIR ]; then
     mkdir -p ${PHP_FPM_RUN_DIR}
     chmod -R a+rwx ${PHP_FPM_RUN_DIR}

--- a/8.3/s2i/bin/run
+++ b/8.3/s2i/bin/run
@@ -56,7 +56,7 @@ fi
 
 
 
-if [ "x$PLATFORM" == "xel9" ] || [ "x$PLATFORM" == "xfedora" ]; then
+if [ "x$PLATFORM" == "xel10" ] || [ "x$PLATFORM" == "xel9" ] || [ "x$PLATFORM" == "xfedora" ]; then
   if [ -n "${PHP_FPM_RUN_DIR:-}" ]; then
     /bin/ln -s /dev/stderr ${PHP_FPM_LOG_PATH}/error.log
     mkdir -p ${PHP_FPM_RUN_DIR}

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ PHP versions currently supported are:
 RHEL versions currently supported are:
 * RHEL8
 * RHEL9
+* RHEL10
 
 CenOS Stream versions currently supported are:
 * CentOS Stream 9

--- a/test/run
+++ b/test/run
@@ -198,7 +198,7 @@ test_application() {
   test_config_writeable
   ct_check_testcase_result $?
 
-  if [ "${OS}" == "rhel9" ] && [ "${PHP_CLEAR_ENV:-ON}" == "OFF" ]; then
+  if [ "${OS}" == "rhel9" ] || [ "${OS}" == "rhel10" ] && [ "${PHP_CLEAR_ENV:-ON}" == "OFF" ]; then
     test_clear_env_setup
     ct_check_testcase_result $?
   fi


### PR DESCRIPTION
This pull request enables building and testing s2i-php-container on RHEL10 host.

The pull request is separated into 2 commits:
1) The first one adds 8.3/Dockerfile.rhel10
2) The second one updates README.md files with RHEL10 information


<!-- issue-commentator = {"comment-id":"2594750818"} -->























































































































































































































































<!-- testing-farm = {"lock":"false","comment-id":"2602206337","data":[{"id":"70815322-a571-4895-8702-3fdc93211b13","name":"CentOS Stream 10 - 8.3","status":"complete","outcome":"passed","runTime":454.659972,"created":"2025-01-31T09:11:31.273729","updated":"2025-01-31T09:11:31.273736","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/70815322-a571-4895-8702-3fdc93211b13\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/70815322-a571-4895-8702-3fdc93211b13/pipeline.log\">pipeline</a>"]},{"id":"c2f9870f-4264-42c3-aa9d-c0a3035eacf0","name":"Fedora - 8.3","status":"complete","outcome":"passed","runTime":657.546225,"created":"2025-01-31T09:11:27.261481","updated":"2025-01-31T09:11:27.261489","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/c2f9870f-4264-42c3-aa9d-c0a3035eacf0\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/c2f9870f-4264-42c3-aa9d-c0a3035eacf0/pipeline.log\">pipeline</a>"]},{"id":"8b5a0cd9-8008-49ee-ae7a-b28891683bb9","name":"Fedora - 8.2","status":"complete","outcome":"passed","runTime":647.437251,"created":"2025-01-31T09:11:25.191059","updated":"2025-01-31T09:11:25.191066","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/8b5a0cd9-8008-49ee-ae7a-b28891683bb9\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/8b5a0cd9-8008-49ee-ae7a-b28891683bb9/pipeline.log\">pipeline</a>"]},{"id":"bb261e3f-b740-426a-b0fd-8050c85fa02c","name":"Fedora - 8.1","status":"complete","outcome":"passed","runTime":641.3748,"created":"2025-01-31T09:11:20.717977","updated":"2025-01-31T09:11:20.717984","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/bb261e3f-b740-426a-b0fd-8050c85fa02c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/bb261e3f-b740-426a-b0fd-8050c85fa02c/pipeline.log\">pipeline</a>"]},{"id":"b6716dcb-abf1-46f2-ba57-302f35a5db34","name":"RHEL10 - 8.3","status":"complete","outcome":"passed","runTime":870.122964,"created":"2025-01-31T09:11:29.791571","updated":"2025-01-31T09:11:29.791578","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b6716dcb-abf1-46f2-ba57-302f35a5db34\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b6716dcb-abf1-46f2-ba57-302f35a5db34/pipeline.log\">pipeline</a>"]},{"id":"d1303df6-6192-46de-bf46-bfb822e9f7d4","name":"RHEL9 - 8.0","status":"complete","outcome":"passed","runTime":941.661367,"created":"2025-01-31T09:11:20.778569","updated":"2025-01-31T09:11:20.778576","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d1303df6-6192-46de-bf46-bfb822e9f7d4\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d1303df6-6192-46de-bf46-bfb822e9f7d4/pipeline.log\">pipeline</a>"]},{"id":"36564614-519d-406c-bcdc-4d92995b1d52","name":"RHEL9 - 8.2","status":"complete","outcome":"passed","runTime":884.272573,"created":"2025-01-29T08:49:15.834186","updated":"2025-01-29T08:49:15.834195","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/36564614-519d-406c-bcdc-4d92995b1d52\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/36564614-519d-406c-bcdc-4d92995b1d52/pipeline.log\">pipeline</a>"]},{"id":"af59dd79-b157-4244-b824-6e558cee287a","name":"RHEL9 - 8.1","status":"complete","outcome":"passed","runTime":834.941845,"created":"2025-01-31T09:11:19.776529","updated":"2025-01-31T09:11:19.776539","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/af59dd79-b157-4244-b824-6e558cee287a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/af59dd79-b157-4244-b824-6e558cee287a/pipeline.log\">pipeline</a>"]},{"id":"9d5bf94b-3b85-44c8-848d-c64f19f46f3f","name":"RHEL8 - 7.4","status":"complete","outcome":"passed","runTime":1010.803355,"created":"2025-01-31T09:11:19.407588","updated":"2025-01-31T09:11:19.407594","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9d5bf94b-3b85-44c8-848d-c64f19f46f3f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9d5bf94b-3b85-44c8-848d-c64f19f46f3f/pipeline.log\">pipeline</a>"]},{"id":"a9578200-48ee-4184-b5d8-d8d246b27a58","name":"RHEL8 - 8.0","status":"complete","outcome":"passed","runTime":935.950657,"created":"2025-01-29T08:49:08.163742","updated":"2025-01-29T08:49:08.163754","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a9578200-48ee-4184-b5d8-d8d246b27a58\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a9578200-48ee-4184-b5d8-d8d246b27a58/pipeline.log\">pipeline</a>"]},{"id":"d1c3a8fe-9ff8-4ae3-8e56-3a493d43daff","name":"RHEL8 - 8.2","runTime":1004.923753,"created":"2025-01-31T09:11:25.502513","updated":"2025-01-31T09:11:25.502521","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d1c3a8fe-9ff8-4ae3-8e56-3a493d43daff\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d1c3a8fe-9ff8-4ae3-8e56-3a493d43daff/pipeline.log\">pipeline</a>"]}]} -->