### PR TITLE
Deprecation PHP-80 image on RHEL8

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [ "7.3", "7.4", "8.0", "8.1", "8.2", "8.3" ]
+        version: [ "7.4", "8.0", "8.1", "8.2", "8.3" ]
         os_test: [ "fedora", "rhel8", "rhel9", "rhel10", "c9s", "c10s"]
         test_case: [ "container" ]
 

--- a/.github/workflows/openshift-pytests.yml
+++ b/.github/workflows/openshift-pytests.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [ "7.3", "7.4", "8.0", "8.1", "8.2" ]
+        version: [ "7.4", "8.0", "8.1", "8.2" ]
         os_test: [ "rhel8", "rhel9", "rhel10" ]
         test_case: [ "openshift-pytest" ]
 

--- a/.github/workflows/openshift-tests.yml
+++ b/.github/workflows/openshift-tests.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [ "7.3", "7.4", "8.0" , "8.1", "8.2" ]
+        version: [ "7.4", "8.0" , "8.1", "8.2" ]
         os_test: [ "rhel8", "rhel9", "rhel10" ]
         test_case: [ "openshift-4" ]
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Include common Makefile code.
 BASE_IMAGE_NAME = php
-VERSIONS = 7.3 7.4 8.0 8.1 8.2 8.3
+VERSIONS = 7.4 8.0 8.1 8.2 8.3
 OPENSHIFT_NAMESPACES =
 
 # HACK:  Ensure that 'git pull' for old clones doesn't cause confusion.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ For more information about concepts used in these container images, see the
 Versions
 --------
 PHP versions currently supported are:
-* [php-7.3](7.3)
 * [php-7.4](7.4)
 * [php-8.0](8.0)
 * [php-8.1](8.1)
@@ -83,8 +82,6 @@ on all the supported versions of PHP.**
 
 Usage
 -----
-For information about usage of Dockerfile for PHP 7.3,
-see [usage documentation](7.3/README.md).
 
 For information about usage of Dockerfile for PHP 7.4,
 see [usage documentation](7.4/README.md).


### PR DESCRIPTION
This pull request deprecates PHP-80 image from RHEL8.

It reached EOL in Nov 2024.

- The first commit adds `.exclude-rhel8` file into 8.0 directory
- The documentation is updated with deprecation 7.3 which is completely EOL. It is removed also from Makefile.


<!-- issue-commentator = {"comment-id":"2618422312"} -->





















































<!-- testing-farm = {"lock":"false","comment-id":"2618460400","data":[{"id":"87bfc95e-6cb8-45c7-8a33-49b9cfd27f0b","name":"RHEL8 - 7.4","status":"complete","outcome":"passed","runTime":967.613162,"created":"2025-01-28T09:33:16.216820","updated":"2025-01-28T09:33:16.216833","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/87bfc95e-6cb8-45c7-8a33-49b9cfd27f0b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/87bfc95e-6cb8-45c7-8a33-49b9cfd27f0b/pipeline.log\">pipeline</a>"]},{"id":"8b4020b6-bcdd-44e0-8377-48915510410e","name":"RHEL9 - 8.2","status":"complete","outcome":"passed","runTime":970.487471,"created":"2025-01-28T09:33:34.952055","updated":"2025-01-28T09:33:34.952062","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8b4020b6-bcdd-44e0-8377-48915510410e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8b4020b6-bcdd-44e0-8377-48915510410e/pipeline.log\">pipeline</a>"]},{"id":"1869aeda-062d-43ae-ae17-289b19b171ab","name":"RHEL8 - 8.2","status":"complete","outcome":"passed","runTime":1001.104682,"created":"2025-01-28T09:33:34.983017","updated":"2025-01-28T09:33:34.983024","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1869aeda-062d-43ae-ae17-289b19b171ab\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1869aeda-062d-43ae-ae17-289b19b171ab/pipeline.log\">pipeline</a>"]},{"id":"f8dcc8ac-fe61-4cbc-9c48-027a40d40342","name":"Fedora - 8.3","status":"complete","outcome":"passed","runTime":1201.888029,"created":"2025-01-28T09:33:40.250384","updated":"2025-01-28T09:33:40.250395","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/f8dcc8ac-fe61-4cbc-9c48-027a40d40342\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/f8dcc8ac-fe61-4cbc-9c48-027a40d40342/pipeline.log\">pipeline</a>"]},{"id":"6e8c3d43-c8b9-47d5-8e4b-e41ac558a8aa","name":"RHEL9 - 8.1","status":"complete","outcome":"passed","runTime":1206.262332,"created":"2025-01-28T09:33:27.930369","updated":"2025-01-28T09:33:27.930380","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6e8c3d43-c8b9-47d5-8e4b-e41ac558a8aa\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6e8c3d43-c8b9-47d5-8e4b-e41ac558a8aa/pipeline.log\">pipeline</a>"]},{"id":"d627c470-58a5-49f3-86e0-78feb5335eef","name":"RHEL9 - 8.0","status":"complete","outcome":"passed","runTime":1666.15472,"created":"2025-01-28T09:33:25.819561","updated":"2025-01-28T09:33:25.819575","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d627c470-58a5-49f3-86e0-78feb5335eef\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d627c470-58a5-49f3-86e0-78feb5335eef/pipeline.log\">pipeline</a>"]},{"id":"2a5f82dc-5769-4449-aa6d-05c85f0feddd","name":"Fedora - 8.2","status":"complete","outcome":"passed","runTime":1762.771089,"created":"2025-01-28T09:33:32.207968","updated":"2025-01-28T09:33:32.207980","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/2a5f82dc-5769-4449-aa6d-05c85f0feddd\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/2a5f82dc-5769-4449-aa6d-05c85f0feddd/pipeline.log\">pipeline</a>"]},{"id":"1e9bb53c-be9e-41d0-ba24-19859b9f2573","name":"Fedora - 8.1","status":"complete","outcome":"passed","runTime":2167.886047,"created":"2025-01-28T09:33:25.355482","updated":"2025-01-28T09:33:25.355494","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/1e9bb53c-be9e-41d0-ba24-19859b9f2573\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/1e9bb53c-be9e-41d0-ba24-19859b9f2573/pipeline.log\">pipeline</a>"]},{"id":"163d599b-12cc-4a8b-ae3c-c15bba29cedf","name":"CentOS Stream 10 - 8.3","runTime":3008.093418,"created":"2025-01-28T09:33:36.997990","updated":"2025-01-28T09:33:36.997999","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.dev.testing-farm.io/163d599b-12cc-4a8b-ae3c-c15bba29cedf\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/163d599b-12cc-4a8b-ae3c-c15bba29cedf/pipeline.log\">pipeline</a>"]}]} -->