### PR TITLE
use ext name instead of pkg name, and add redis

### DIFF
--- a/8.3/Dockerfile.c10s
+++ b/8.3/Dockerfile.c10s
@@ -44,7 +44,7 @@ LABEL summary="${SUMMARY}" \
 ARG INSTALL_PKGS="php php-fpm php-mysqlnd php-pgsql php-bcmath \
                   php-gd php-intl php-ldap php-mbstring php-pdo \
                   php-process php-soap php-opcache php-xml \
-                  php-gmp php-pecl-apcu php-pecl-zip mod_ssl hostname"
+                  php-gmp php-apcu php-zip php-redis mod_ssl hostname"
 
 RUN dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     dnf reinstall -y tzdata && \

--- a/8.3/Dockerfile.c10s
+++ b/8.3/Dockerfile.c10s
@@ -41,15 +41,19 @@ LABEL summary="${SUMMARY}" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 # Install Apache httpd and PHP
-ARG INSTALL_PKGS="php php-fpm php-mysqlnd php-pgsql php-bcmath \
+ARG INSTALL_PKGS="php php-fpm mod_ssl hostname"
+ARG INSTALL_EXTS="php-json php-mysqli php-pgsql php-bcmath \
                   php-gd php-intl php-ldap php-mbstring php-pdo \
                   php-process php-soap php-opcache php-xml \
-                  php-gmp php-apcu php-zip php-redis mod_ssl hostname"
+                  php-gmp php-apcu php-zip php-redis"
 
-RUN dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+RUN dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS $INSTALL_EXTS && \
     dnf reinstall -y tzdata && \
     rpm -V $INSTALL_PKGS && \
-    php -v | grep -qe "v$PHP_VERSION\." && echo "Found VERSION $PHP_VERSION" && \
+    php -v | grep -qe "v$PHP_VERSION\." && \
+        echo "Found VERSION $PHP_VERSION" && \
+    for ext in $(echo $INSTALL_EXTS | sed s/php-//g) ; do php -m | grep -qi "$ext\$"; done && \
+        echo "Found requested extensions" && \
     dnf -y clean all --enablerepo='*'
 
 ENV PHP_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/php/ \

--- a/8.3/Dockerfile.c9s
+++ b/8.3/Dockerfile.c9s
@@ -41,16 +41,20 @@ LABEL summary="${SUMMARY}" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 # Install Apache httpd and PHP
-ARG INSTALL_PKGS="php php-fpm php-mysqlnd php-pgsql php-bcmath \
+ARG INSTALL_PKGS="php php-fpm mod_ssl hostname"
+ARG INSTALL_EXTS="php-json php-mysqli php-pgsql php-bcmath \
                   php-gd php-intl php-ldap php-mbstring php-pdo \
                   php-process php-soap php-opcache php-xml \
-                  php-gmp php-apcu php-zip php-redis mod_ssl hostname"
+                  php-gmp php-apcu php-zip php-redis"
 
 RUN dnf module -y enable php:$PHP_VERSION && \
-    dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS $INSTALL_EXTS && \
     dnf reinstall -y tzdata && \
     rpm -V $INSTALL_PKGS && \
-    php -v | grep -qe "v$PHP_VERSION\." && echo "Found VERSION $PHP_VERSION" && \
+    php -v | grep -qe "v$PHP_VERSION\." && \
+        echo "Found VERSION $PHP_VERSION" && \
+    for ext in $(echo $INSTALL_EXTS | sed s/php-//g) ; do php -m | grep -qi "$ext\$"; done && \
+        echo "Found requested extensions" && \
     dnf -y clean all --enablerepo='*'
 
 ENV PHP_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/php/ \

--- a/8.3/Dockerfile.c9s
+++ b/8.3/Dockerfile.c9s
@@ -44,7 +44,7 @@ LABEL summary="${SUMMARY}" \
 ARG INSTALL_PKGS="php php-fpm php-mysqlnd php-pgsql php-bcmath \
                   php-gd php-intl php-ldap php-mbstring php-pdo \
                   php-process php-soap php-opcache php-xml \
-                  php-gmp php-pecl-apcu php-pecl-zip mod_ssl hostname"
+                  php-gmp php-apcu php-zip php-redis mod_ssl hostname"
 
 RUN dnf module -y enable php:$PHP_VERSION && \
     dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \

--- a/8.3/Dockerfile.fedora
+++ b/8.3/Dockerfile.fedora
@@ -40,7 +40,7 @@ LABEL summary="$SUMMARY" \
 ARG INSTALL_PKGS="php php-fpm php-mysqlnd php-bcmath \
                   php-gd php-intl php-ldap php-mbstring php-pdo \
                   php-process php-soap php-opcache php-xml \
-                  php-gmp php-pecl-apcu mod_ssl hostname"
+                  php-gmp php-apcu php-zip php-redis mod_ssl hostname"
 
 RUN dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS --nogpgcheck && \
     rpm -V $INSTALL_PKGS && \

--- a/8.3/Dockerfile.fedora
+++ b/8.3/Dockerfile.fedora
@@ -37,14 +37,18 @@ LABEL summary="$SUMMARY" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 # Install Apache httpd and PHP
-ARG INSTALL_PKGS="php php-fpm php-mysqlnd php-bcmath \
+ARG INSTALL_PKGS="php php-fpm mod_ssl hostname"
+ARG INSTALL_EXTS="php-json php-mysqli php-pgsql php-bcmath \
                   php-gd php-intl php-ldap php-mbstring php-pdo \
                   php-process php-soap php-opcache php-xml \
-                  php-gmp php-apcu php-zip php-redis mod_ssl hostname"
+                  php-gmp php-apcu php-zip php-redis"
 
-RUN dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS --nogpgcheck && \
+RUN dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS $INSTALL_EXTS --nogpgcheck && \
     rpm -V $INSTALL_PKGS && \
-    php -v | grep -qe "v$PHP_VERSION\." && echo "Found VERSION $PHP_VERSION" && \
+    php -v | grep -qe "v$PHP_VERSION\." && \
+        echo "Found VERSION $PHP_VERSION" && \
+    for ext in $(echo $INSTALL_EXTS | sed s/php-//g) ; do php -m | grep -qi "$ext\$"; done && \
+        echo "Found requested extensions" && \
     dnf -y clean all --enablerepo='*'
 
 ENV PHP_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/php/ \

--- a/8.3/Dockerfile.rhel9
+++ b/8.3/Dockerfile.rhel9
@@ -41,16 +41,20 @@ LABEL summary="${SUMMARY}" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 # Install Apache httpd and PHP
-ARG INSTALL_PKGS="php php-fpm php-mysqlnd php-pgsql php-bcmath \
+ARG INSTALL_PKGS="php php-fpm mod_ssl hostname"
+ARG INSTALL_EXTS="php-json php-mysqli php-pgsql php-bcmath \
                   php-gd php-intl php-ldap php-mbstring php-pdo \
                   php-process php-soap php-opcache php-xml \
-                  php-gmp php-apcu php-zip php-redis mod_ssl hostname"
+                  php-gmp php-apcu php-zip php-redis"
 
 RUN dnf module -y enable php:$PHP_VERSION && \
-    dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS $INSTALL_EXTS && \
     dnf reinstall -y tzdata && \
     rpm -V $INSTALL_PKGS && \
-    php -v | grep -qe "v$PHP_VERSION\." && echo "Found VERSION $PHP_VERSION" && \
+    php -v | grep -qe "v$PHP_VERSION\." && \
+        echo "Found VERSION $PHP_VERSION" && \
+    for ext in $(echo $INSTALL_EXTS | sed s/php-//g) ; do php -m | grep -qi "$ext\$"; done && \
+        echo "Found requested extensions" && \
     dnf -y clean all --enablerepo='*'
 
 ENV PHP_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/php/ \

--- a/8.3/Dockerfile.rhel9
+++ b/8.3/Dockerfile.rhel9
@@ -44,7 +44,7 @@ LABEL summary="${SUMMARY}" \
 ARG INSTALL_PKGS="php php-fpm php-mysqlnd php-pgsql php-bcmath \
                   php-gd php-intl php-ldap php-mbstring php-pdo \
                   php-process php-soap php-opcache php-xml \
-                  php-gmp php-pecl-apcu php-pecl-zip mod_ssl hostname"
+                  php-gmp php-apcu php-zip php-redis mod_ssl hostname"
 
 RUN dnf module -y enable php:$PHP_VERSION && \
     dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \


### PR DESCRIPTION
Main benefit: will install the extension, whatever the package name is, and latest version, ex:

- zip => php-zip => php-pecl-zip
- json => php-pecl-json => php-json => php-common (since 8.0)
- redis => php-pecl-redis3 => php-pecl-redis5 => php-pecl-redis6
- etc

By packaging Guidelines, the `php-<extname>` is always provided and is the only reliable name
https://docs.fedoraproject.org/en-US/packaging-guidelines/PHP/#requires-provides-c

<!-- issue-commentator = {"comment-id":"2624062178"} -->























































































































































<!-- testing-farm = {"lock":"false","comment-id":"2624255144","data":[{"id":"49ff4ebd-75bc-4f43-9c18-4689a531976c","name":"CentOS Stream 10 - 8.3","status":"complete","outcome":"passed","runTime":480.661565,"created":"2025-01-30T15:53:54.674796","updated":"2025-01-30T15:53:54.674806","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/49ff4ebd-75bc-4f43-9c18-4689a531976c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/49ff4ebd-75bc-4f43-9c18-4689a531976c/pipeline.log\">pipeline</a>"]},{"id":"d84e2127-7d51-464a-9e93-d7f1eb72be49","name":"Fedora - 8.3","status":"complete","outcome":"passed","runTime":639.308922,"created":"2025-01-30T15:53:58.641161","updated":"2025-01-30T15:53:58.641171","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/d84e2127-7d51-464a-9e93-d7f1eb72be49\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/d84e2127-7d51-464a-9e93-d7f1eb72be49/pipeline.log\">pipeline</a>"]},{"id":"b31ceafd-8007-4c4c-a800-43f8f2126f70","name":"Fedora - 8.1","status":"complete","outcome":"passed","runTime":628.477828,"created":"2025-01-30T15:53:46.671452","updated":"2025-01-30T15:53:46.671464","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/b31ceafd-8007-4c4c-a800-43f8f2126f70\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/b31ceafd-8007-4c4c-a800-43f8f2126f70/pipeline.log\">pipeline</a>"]},{"id":"ce39e258-6679-478b-a618-4755ad70a8d4","name":"Fedora - 8.2","status":"complete","outcome":"passed","runTime":630.187597,"created":"2025-01-30T15:53:53.818391","updated":"2025-01-30T15:53:53.818400","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/ce39e258-6679-478b-a618-4755ad70a8d4\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/ce39e258-6679-478b-a618-4755ad70a8d4/pipeline.log\">pipeline</a>"]},{"id":"b5c13ee9-c845-41e4-9d6f-7b8644faf46f","name":"RHEL9 - 8.2","status":"complete","outcome":"passed","runTime":814.777387,"created":"2025-01-30T15:53:55.644434","updated":"2025-01-30T15:53:55.644444","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b5c13ee9-c845-41e4-9d6f-7b8644faf46f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b5c13ee9-c845-41e4-9d6f-7b8644faf46f/pipeline.log\">pipeline</a>"]},{"id":"5e1f991a-7466-44f5-a2bd-450a156e3baa","name":"RHEL9 - 8.0","status":"complete","outcome":"passed","runTime":821.259608,"created":"2025-01-30T15:53:49.957601","updated":"2025-01-30T15:53:49.957613","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5e1f991a-7466-44f5-a2bd-450a156e3baa\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5e1f991a-7466-44f5-a2bd-450a156e3baa/pipeline.log\">pipeline</a>"]},{"id":"e0b16a72-7a95-4d83-83fd-399b6b5b169d","name":"RHEL9 - 8.1","status":"complete","outcome":"passed","runTime":859.805514,"created":"2025-01-30T15:53:50.686524","updated":"2025-01-30T15:53:50.686531","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e0b16a72-7a95-4d83-83fd-399b6b5b169d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e0b16a72-7a95-4d83-83fd-399b6b5b169d/pipeline.log\">pipeline</a>"]},{"id":"e9cd1f5f-b678-4cd6-9713-34785cde2472","name":"RHEL8 - 8.2","runTime":939.88849,"created":"2025-01-30T15:53:54.518059","updated":"2025-01-30T15:53:54.518069","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e9cd1f5f-b678-4cd6-9713-34785cde2472\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e9cd1f5f-b678-4cd6-9713-34785cde2472/pipeline.log\">pipeline</a>"]},{"id":"542c10e3-17a0-4c4c-ad08-69b906ec1b42","name":"RHEL8 - 7.4","status":"complete","outcome":"passed","runTime":938.976327,"created":"2025-01-30T15:53:48.889905","updated":"2025-01-30T15:53:48.889919","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/542c10e3-17a0-4c4c-ad08-69b906ec1b42\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/542c10e3-17a0-4c4c-ad08-69b906ec1b42/pipeline.log\">pipeline</a>"]}]} -->