### PR TITLE
Helm Charts have been rename to 'redhat-' prefix

### DIFF
--- a/test/test_shared_helm_cakephp_application.py
+++ b/test/test_shared_helm_cakephp_application.py
@@ -36,7 +36,7 @@ TAG = TAGS.get(OS, None)
 class TestHelmCakePHPTemplate:
 
     def setup_method(self):
-        package_name = "php-cakephp-application"
+        package_name = "redhat-php-cakephp-application"
         path = test_dir
         self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, remote=True)
         self.hc_api.clone_helm_chart_repo(
@@ -50,10 +50,10 @@ class TestHelmCakePHPTemplate:
     def test_curl_connection(self):
         if self.hc_api.oc_api.shared_cluster:
             pytest.skip("Do NOT test on shared cluster")
-        self.hc_api.package_name = "php-imagestreams"
+        self.hc_api.package_name = "redhat-php-imagestreams"
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation()
-        self.hc_api.package_name = "php-cakephp-application"
+        self.hc_api.package_name = "redhat-php-cakephp-application"
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation(
             values={
@@ -68,10 +68,10 @@ class TestHelmCakePHPTemplate:
         )
 
     def test_by_helm_test(self):
-        self.hc_api.package_name = "php-imagestreams"
+        self.hc_api.package_name = "redhat-php-imagestreams"
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation()
-        self.hc_api.package_name = "php-cakephp-application"
+        self.hc_api.package_name = "redhat-php-cakephp-application"
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation(
             values={

--- a/test/test_shared_helm_chart_imagestreams.py
+++ b/test/test_shared_helm_chart_imagestreams.py
@@ -18,7 +18,7 @@ test_dir = Path(os.path.abspath(os.path.dirname(__file__)))
 class TestHelmRHELPHPImageStreams:
 
     def setup_method(self):
-        package_name = "php-imagestreams"
+        package_name = "redhat-php-imagestreams"
         path = test_dir
         self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, remote=True)
         self.hc_api.clone_helm_chart_repo(


### PR DESCRIPTION
In order to preserve structure in https://github.com/openshift-helm-charts/charts helm chart was renamed


<!-- issue-commentator = {"comment-id":"2647953872"} -->





















































<!-- testing-farm = {"lock":"false","comment-id":"2648037195","data":[{"id":"813bbab8-30d9-4ad4-9008-d25e72463b54","name":"RHEL9 - OpenShift 4 - 8.1","status":"complete","outcome":"passed","runTime":1887.035837,"created":"2025-02-10T13:14:44.321753","updated":"2025-02-10T13:14:44.321760","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/813bbab8-30d9-4ad4-9008-d25e72463b54\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/813bbab8-30d9-4ad4-9008-d25e72463b54/pipeline.log\">pipeline</a>"]},{"id":"5d4f4752-cba9-4714-994c-293e25621121","name":"RHEL9 - OpenShift 4 - 8.2","status":"complete","outcome":"passed","runTime":1946.366848,"created":"2025-02-10T13:14:54.985245","updated":"2025-02-10T13:14:54.985252","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5d4f4752-cba9-4714-994c-293e25621121\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5d4f4752-cba9-4714-994c-293e25621121/pipeline.log\">pipeline</a>"]},{"id":"986bdca4-52b0-4090-a338-30077149be54","name":"RHEL8 - OpenShift 4 - 7.4","status":"complete","outcome":"passed","runTime":2030.52193,"created":"2025-02-10T13:14:37.807314","updated":"2025-02-10T13:14:37.807321","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/986bdca4-52b0-4090-a338-30077149be54\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/986bdca4-52b0-4090-a338-30077149be54/pipeline.log\">pipeline</a>"]},{"id":"9d7bc71b-28ea-42b3-99dc-64522dc5766d","name":"RHEL9 - PyTest - OpenShift 4 - 8.0","status":"complete","outcome":"error","runTime":2121.161842,"created":"2025-02-10T13:14:28.701708","updated":"2025-02-10T13:14:28.701719","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9d7bc71b-28ea-42b3-99dc-64522dc5766d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9d7bc71b-28ea-42b3-99dc-64522dc5766d/pipeline.log\">pipeline</a>"]},{"id":"9b09baa2-3199-43fc-964f-db6db44de734","name":"RHEL9 - PyTest - OpenShift 4 - 8.2","status":"complete","outcome":"error","runTime":2228.686121,"created":"2025-02-10T13:14:30.522596","updated":"2025-02-10T13:14:30.522602","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9b09baa2-3199-43fc-964f-db6db44de734\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9b09baa2-3199-43fc-964f-db6db44de734/pipeline.log\">pipeline</a>"]},{"id":"73b4695a-71fc-4e56-8a24-00c28000fdda","name":"RHEL8 - PyTest - OpenShift 4 - 8.2","status":"complete","outcome":"error","runTime":2290.709578,"created":"2025-02-10T13:14:29.984995","updated":"2025-02-10T13:14:29.985002","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/73b4695a-71fc-4e56-8a24-00c28000fdda\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/73b4695a-71fc-4e56-8a24-00c28000fdda/pipeline.log\">pipeline</a>"]},{"id":"d492bebd-4773-4a33-9e13-cef819a866ce","name":"RHEL9 - PyTest - OpenShift 4 - 8.1","status":"complete","outcome":"error","runTime":2599.102623,"created":"2025-02-10T13:14:30.118916","updated":"2025-02-10T13:14:30.118921","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d492bebd-4773-4a33-9e13-cef819a866ce\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d492bebd-4773-4a33-9e13-cef819a866ce/pipeline.log\">pipeline</a>"]},{"id":"9a337148-d201-4752-8b3c-5aa45fc0974e","name":"RHEL8 - PyTest - OpenShift 4 - 7.4","status":"complete","outcome":"error","runTime":2772.360155,"created":"2025-02-10T13:14:29.741813","updated":"2025-02-10T13:14:29.741820","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9a337148-d201-4752-8b3c-5aa45fc0974e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9a337148-d201-4752-8b3c-5aa45fc0974e/pipeline.log\">pipeline</a>"]},{"id":"3f19d090-cf91-43de-977c-6b649786395f","name":"RHEL9 - OpenShift 4 - 8.0","runTime":4852.596883,"created":"2025-02-10T13:15:28.345957","updated":"2025-02-10T13:15:28.345964","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"error","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3f19d090-cf91-43de-977c-6b649786395f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3f19d090-cf91-43de-977c-6b649786395f/pipeline.log\">pipeline</a>"]}]} -->