### PR TITLE
s2i-core and s2i-base images are available from unauthenticated registries

### DIFF
--- a/8.3/Dockerfile.rhel10
+++ b/8.3/Dockerfile.rhel10
@@ -47,10 +47,6 @@ ARG INSTALL_EXTS="php-json php-mysqli php-pgsql php-bcmath \
                   php-process php-soap php-opcache php-xml \
                   php-gmp php-apcu php-zip php-redis"
 
-# This needs to be added for downloading packages
-RUN curl -fL -o /etc/pki/ca-trust/source/anchors/2022-IT-Root-CA.pem https://certs.corp.redhat.com/certs/2022-IT-Root-CA.pem
-RUN update-ca-trust extract
-
 RUN dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS $INSTALL_EXTS && \
     dnf reinstall -y tzdata && \
     rpm -V $INSTALL_PKGS && \
@@ -59,10 +55,6 @@ RUN dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS $INSTALL_EXTS && \
     for ext in $(echo $INSTALL_EXTS | sed s/php-//g) ; do php -m | grep -qi "$ext\$"; done && \
         echo "Found requested extensions" && \
     dnf -y clean all --enablerepo='*'
-
-# Remove the certs
-RUN rm /etc/pki/ca-trust/source/anchors/2022-IT-Root-CA.pem
-RUN update-ca-trust
 
 ENV PHP_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/php/ \
     APP_DATA=${APP_ROOT}/src \


### PR DESCRIPTION
Certificates are not need at all in Dockerfile.
Remove these certificates.

See JIRA: https://issues.redhat.com/browse/ENGCMP-5283

<!-- issue-commentator = {"comment-id":"2801563125"} -->

<!-- testing-farm = {"lock":"false","comment-id":"2801582158","data":[{"id":"71cca494-042e-46a9-8a58-eb246dd0c762","name":"CentOS Stream 10 - 8.3","status":"complete","outcome":"passed","runTime":403.266203,"created":"2025-04-14T12:33:03.016384","updated":"2025-04-14T12:33:03.016391","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/71cca494-042e-46a9-8a58-eb246dd0c762\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/71cca494-042e-46a9-8a58-eb246dd0c762/pipeline.log\">pipeline</a>"]},{"id":"02872b3b-c409-425b-aca2-298365fef679","name":"CentOS Stream 9 - 8.3","status":"complete","outcome":"passed","runTime":435.575972,"created":"2025-04-14T12:33:05.640824","updated":"2025-04-14T12:33:05.640829","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/02872b3b-c409-425b-aca2-298365fef679\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/02872b3b-c409-425b-aca2-298365fef679/pipeline.log\">pipeline</a>"]},{"id":"2ff3bd31-bfc5-4438-8abd-1007712b0dfc","name":"Fedora - 8.3","status":"complete","outcome":"passed","runTime":500.570088,"created":"2025-04-14T12:33:04.497613","updated":"2025-04-14T12:33:04.497620","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/2ff3bd31-bfc5-4438-8abd-1007712b0dfc\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/2ff3bd31-bfc5-4438-8abd-1007712b0dfc/pipeline.log\">pipeline</a>"]},{"id":"054b6950-5af8-4eae-a9be-46cc8b27b27d","name":"Fedora - 8.2","status":"complete","outcome":"passed","runTime":582.142975,"created":"2025-04-14T12:33:07.173774","updated":"2025-04-14T12:33:07.173782","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/054b6950-5af8-4eae-a9be-46cc8b27b27d\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/054b6950-5af8-4eae-a9be-46cc8b27b27d/pipeline.log\">pipeline</a>"]},{"id":"ce55d151-22a2-4c2d-92f9-315385cfa38f","name":"Fedora - 8.1","status":"complete","outcome":"passed","runTime":580.195231,"created":"2025-04-14T12:33:10.030799","updated":"2025-04-14T12:33:10.030807","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/ce55d151-22a2-4c2d-92f9-315385cfa38f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/ce55d151-22a2-4c2d-92f9-315385cfa38f/pipeline.log\">pipeline</a>"]},{"id":"7b867e2c-e596-4af3-80ae-6907070a7283","name":"RHEL9 - 8.1","status":"complete","outcome":"passed","runTime":1425.785807,"created":"2025-04-14T12:33:00.500338","updated":"2025-04-14T12:33:00.500345","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7b867e2c-e596-4af3-80ae-6907070a7283\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7b867e2c-e596-4af3-80ae-6907070a7283/pipeline.log\">pipeline</a>"]},{"id":"3a2f1ac7-55c2-4d1d-a7d8-33ffc790c33b","name":"RHEL10 - 8.3","status":"complete","outcome":"passed","runTime":1461.30209,"created":"2025-04-14T12:33:00.282690","updated":"2025-04-14T12:33:00.282698","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3a2f1ac7-55c2-4d1d-a7d8-33ffc790c33b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3a2f1ac7-55c2-4d1d-a7d8-33ffc790c33b/pipeline.log\">pipeline</a>"]},{"id":"e7ddcca3-d6f5-4af8-b7c3-5cda43e12cce","name":"RHEL9 - 8.2","status":"complete","outcome":"passed","runTime":1499.231097,"created":"2025-04-14T12:33:06.606163","updated":"2025-04-14T12:33:06.606169","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e7ddcca3-d6f5-4af8-b7c3-5cda43e12cce\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e7ddcca3-d6f5-4af8-b7c3-5cda43e12cce/pipeline.log\">pipeline</a>"]},{"id":"a627bc53-1f49-499e-9905-b43490802acb","name":"RHEL9 - 8.0","status":"complete","outcome":"passed","runTime":1518.479168,"created":"2025-04-14T12:33:00.435383","updated":"2025-04-14T12:33:00.435391","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a627bc53-1f49-499e-9905-b43490802acb\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a627bc53-1f49-499e-9905-b43490802acb/pipeline.log\">pipeline</a>"]},{"id":"f77cdc64-b239-4fbd-9c89-1b5313f44852","name":"RHEL8 - 8.2","status":"complete","outcome":"passed","runTime":1566.052637,"created":"2025-04-14T12:33:03.054798","updated":"2025-04-14T12:33:03.054805","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f77cdc64-b239-4fbd-9c89-1b5313f44852\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f77cdc64-b239-4fbd-9c89-1b5313f44852/pipeline.log\">pipeline</a>"]},{"id":"bc364afb-7ac2-4d36-843e-b8dd613f382f","name":"RHEL9 - 8.3","status":"complete","outcome":"passed","runTime":1554.573981,"created":"2025-04-14T12:33:08.147276","updated":"2025-04-14T12:33:08.147282","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/bc364afb-7ac2-4d36-843e-b8dd613f382f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/bc364afb-7ac2-4d36-843e-b8dd613f382f/pipeline.log\">pipeline</a>"]},{"id":"52090539-fe72-4259-b41c-e9d5ff437480","name":"RHEL8 - 7.4","runTime":1734.566688,"created":"2025-04-14T12:33:10.647059","updated":"2025-04-14T12:33:10.647065","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/52090539-fe72-4259-b41c-e9d5ff437480\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/52090539-fe72-4259-b41c-e9d5ff437480/pipeline.log\">pipeline</a>"]}]} -->