### PR TITLE
Do not tests imagestreams on RHEL10 yet

### DIFF
--- a/test/test-lib-php.sh
+++ b/test/test-lib-php.sh
@@ -20,7 +20,10 @@ function test_php_integration() {
 
 # Check the imagestream
 function test_php_imagestream() {
-
+  if [ "$OS" == "rhel10" ]; then
+    echo "Imagestreams are not released yet for RHEL10. Let's skip this test."
+    return
+  fi
   ct_os_test_image_stream_s2i "${THISDIR}/imagestreams/php-${OS%[0-9]*}.json" "${IMAGE_NAME}" \
                               "https://github.com/sclorg/s2i-php-container.git" \
                               test/test-app \
@@ -31,6 +34,10 @@ function test_php_imagestream() {
 function test_php_template() {
   local supported_use_case
   local check_msg
+  if [ "$OS" == "rhel10" ]; then
+    echo "Imagestreams are not released yet for RHEL10. Let's skip this test."
+    return
+  fi
   if [ "${VERSION}" == "7.4" ] || [ "${VERSION}" == "8.0" ]; then
     supported_use_case="True"
     BRANCH_TO_TEST="4.X"

--- a/test/test_php_deploy_templates.py
+++ b/test/test_php_deploy_templates.py
@@ -38,7 +38,7 @@ TAG = TAGS.get(OS, None)
 class TestDeployTemplate:
 
     def setup_method(self):
-        self.oc_api = OpenShiftAPI(pod_name_prefix="php-testing", version=VERSION, shared_cluster=True)
+        self.oc_api = OpenShiftAPI(pod_name_prefix="php-testing", version=VERSION)
         self.oc_api.import_is("imagestreams/php-rhel.json", "", skip_check=True)
         #assert self.oc_api.upload_image(DEPLOYED_MYSQL_IMAGE, IMAGE_SHORT)
 
@@ -52,7 +52,8 @@ class TestDeployTemplate:
         ]
     )
     def test_php_template_inside_cluster(self, template):
-
+        if OS == "rhel10":
+            pytest.skip("Do NOT test on RHEL10 yet.")
         service_name = "php-testing"
         template_url = self.oc_api.get_raw_url_for_json(
             container="cakephp-ex", dir="openshift/templates", filename=template, branch=branch_to_test
@@ -74,7 +75,7 @@ class TestDeployTemplate:
             name_in_template="php",
             openshift_args=openshift_args
         )
-        assert self.oc_api.template_deployed(name_in_template=service_name)
+        assert self.oc_api.is_template_deployed(name_in_template=service_name)
         assert self.oc_api.check_response_inside_cluster(
             name_in_template=service_name, expected_output=check_msg
         )

--- a/test/test_php_deploy_templates.py
+++ b/test/test_php_deploy_templates.py
@@ -30,6 +30,8 @@ TAGS = {
 }
 TAG = TAGS.get(OS, None)
 
+new_version = VERSION.replace(".", "")
+
 # DEPLOYED_MYSQL_IMAGE = "quay.io/sclorg/mysql-80-c9s"
 # IMAGE_SHORT = f"mysql:8.0-el9"
 # IMAGE_TAG = f"8.0-el9"
@@ -38,8 +40,7 @@ TAG = TAGS.get(OS, None)
 class TestDeployTemplate:
 
     def setup_method(self):
-        self.oc_api = OpenShiftAPI(pod_name_prefix="php-testing", version=VERSION)
-        self.oc_api.import_is("imagestreams/php-rhel.json", "", skip_check=True)
+        self.oc_api = OpenShiftAPI(pod_name_prefix=f"php-{new_version}-testing", version=VERSION)
         #assert self.oc_api.upload_image(DEPLOYED_MYSQL_IMAGE, IMAGE_SHORT)
 
     def teardown_method(self):
@@ -54,7 +55,10 @@ class TestDeployTemplate:
     def test_php_template_inside_cluster(self, template):
         if OS == "rhel10":
             pytest.skip("Do NOT test on RHEL10 yet.")
-        service_name = "php-testing"
+        if VERSION == "8.3":
+            pytest.skip("Do NOT test on version 8.3 yet.")
+        self.oc_api.import_is("imagestreams/php-rhel.json", "", skip_check=True)
+        service_name = f"php-{new_version}-testing"
         template_url = self.oc_api.get_raw_url_for_json(
             container="cakephp-ex", dir="openshift/templates", filename=template, branch=branch_to_test
         )

--- a/test/test_php_s2i_imagestreams.py
+++ b/test/test_php_s2i_imagestreams.py
@@ -29,6 +29,8 @@ class TestPHPImagestreams:
     def test_php_template_inside_cluster(self):
         if OS == "rhel10":
             pytest.skip("Do NOT test on RHEL10 yet.")
+        if VERSION == "8.3":
+            pytest.skip("Do NOT test on version 8.3 yet.")
         service_name = f"php-{SHORT_VERSION}-testing"
         assert self.oc_api.deploy_imagestream_s2i(
             imagestream_file="imagestreams/php-rhel.json",

--- a/test/test_php_s2i_imagestreams.py
+++ b/test/test_php_s2i_imagestreams.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import pytest
 
 from container_ci_suite.openshift import OpenShiftAPI
 from container_ci_suite.utils import check_variables
@@ -20,20 +21,23 @@ SHORT_VERSION = "".join(VERSION.split("."))
 class TestPHPImagestreams:
 
     def setup_method(self):
-        self.oc_api = OpenShiftAPI(pod_name_prefix="php", version=VERSION, shared_cluster=True)
+        self.oc_api = OpenShiftAPI(pod_name_prefix="php", version=VERSION)
 
     def teardown_method(self):
         self.oc_api.delete_project()
 
     def test_php_template_inside_cluster(self):
+        if OS == "rhel10":
+            pytest.skip("Do NOT test on RHEL10 yet.")
         service_name = f"php-{SHORT_VERSION}-testing"
         assert self.oc_api.deploy_imagestream_s2i(
             imagestream_file="imagestreams/php-rhel.json",
             image_name=IMAGE_NAME,
             app="https://github.com/sclorg/s2i-php-container.git",
-            context="test/test-app"
+            context="test/test-app",
+            service_name=service_name
         )
-        assert self.oc_api.template_deployed(name_in_template=service_name)
+        assert self.oc_api.is_template_deployed(name_in_template=service_name, timeout=480)
         assert self.oc_api.check_response_inside_cluster(
             name_in_template=service_name, expected_output="Test PHP passed"
         )

--- a/test/test_php_s2i_integration.py
+++ b/test/test_php_s2i_integration.py
@@ -18,7 +18,7 @@ OS = os.getenv("TARGET")
 class TestS2IPHPTemplate:
 
     def setup_method(self):
-        self.oc_api = OpenShiftAPI(pod_name_prefix="php-testing", version=VERSION, shared_cluster=True)
+        self.oc_api = OpenShiftAPI(pod_name_prefix="php-testing", version=VERSION)
 
     def teardown_method(self):
         self.oc_api.delete_project()
@@ -30,7 +30,7 @@ class TestS2IPHPTemplate:
             context="test/test-app",
             service_name=service_name
         )
-        assert self.oc_api.template_deployed(name_in_template=service_name)
+        assert self.oc_api.is_template_deployed(name_in_template=service_name, timeout=480)
         assert self.oc_api.check_response_inside_cluster(
             name_in_template=service_name, expected_output="Test PHP passed"
         )

--- a/test/test_php_s2i_integration.py
+++ b/test/test_php_s2i_integration.py
@@ -12,19 +12,19 @@ if not check_variables():
 VERSION = os.getenv("VERSION")
 IMAGE_NAME = os.getenv("IMAGE_NAME")
 OS = os.getenv("TARGET")
-
+new_version = VERSION.replace(".", "")
 
 # Replacement with 'test_python_s2i_app_ex'
 class TestS2IPHPTemplate:
 
     def setup_method(self):
-        self.oc_api = OpenShiftAPI(pod_name_prefix="php-testing", version=VERSION)
+        self.oc_api = OpenShiftAPI(pod_name_prefix=f"php-{new_version}-testing", version=VERSION)
 
     def teardown_method(self):
         self.oc_api.delete_project()
 
     def test_php_template_inside_cluster(self):
-        service_name = "php-testing"
+        service_name = f"php-{new_version}-testing"
         assert self.oc_api.deploy_s2i_app(
             image_name=IMAGE_NAME, app=f"https://github.com/sclorg/s2i-php-container.git",
             context="test/test-app",

--- a/test/test_shared_helm_cakephp_application.py
+++ b/test/test_shared_helm_cakephp_application.py
@@ -38,7 +38,7 @@ class TestHelmCakePHPTemplate:
     def setup_method(self):
         package_name = "redhat-php-cakephp-application"
         path = test_dir
-        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, shared_cluster=True)
+        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
         self.hc_api.clone_helm_chart_repo(
             repo_url="https://github.com/sclorg/helm-charts", repo_name="helm-charts",
             subdir="charts/redhat"
@@ -68,7 +68,7 @@ class TestHelmCakePHPTemplate:
                 "name": "cakephp-example"
             }
         )
-        assert self.hc_api.is_s2i_pod_running(pod_name_prefix="cakephp-example", timeout=300)
+        assert self.hc_api.is_s2i_pod_running(pod_name_prefix="cakephp-example", timeout=480)
         assert self.hc_api.oc_api.check_response_inside_cluster(
             name_in_template="cakephp-example",
             expected_output=check_msg,
@@ -93,5 +93,5 @@ class TestHelmCakePHPTemplate:
                 "name": "cakephp-example"
             }
         )
-        assert self.hc_api.is_s2i_pod_running(pod_name_prefix="cakephp-example", timeout=300)
+        assert self.hc_api.is_s2i_pod_running(pod_name_prefix="cakephp-example", timeout=480)
         assert self.hc_api.test_helm_chart(expected_str=[check_msg])

--- a/test/test_shared_helm_cakephp_application.py
+++ b/test/test_shared_helm_cakephp_application.py
@@ -48,6 +48,11 @@ class TestHelmCakePHPTemplate:
         self.hc_api.delete_project()
 
     def test_curl_connection(self):
+        if OS == "rhel10":
+            pytest.skip("Do NOT test on RHEL10 yet.")
+        if VERSION == "8.3":
+            pytest.skip("Do NOT test on version 8.3 yet.")
+
         branch_to_test = "4.X"
         check_msg = "Welcome to CakePHP"
         if self.hc_api.shared_cluster:
@@ -75,6 +80,10 @@ class TestHelmCakePHPTemplate:
         )
 
     def test_by_helm_test(self):
+        if OS == "rhel10":
+            pytest.skip("Do NOT test on RHEL10 yet.")
+        if VERSION == "8.3":
+            pytest.skip("Do NOT test on version 8.3 yet.")
         branch_to_test = "4.X"
         check_msg = "Welcome to CakePHP"
         if VERSION.startswith("8.2") or VERSION.startswith("8.3"):


### PR DESCRIPTION
Do not test imagestreams on RHEL10 yet.
They do not exist.

Fix PyTest API test suite. Function has been renamed.

<!-- issue-commentator = {"comment-id":"2834781595"} -->

<!-- testing-farm = {"lock":"false","comment-id":"2834830290","data":[{"id":"9c3c22c5-72a5-4715-8bb4-0dffeed998b1","name":"RHEL8 - OpenShift 4 - 7.4","status":"complete","outcome":"passed","runTime":3563.314976,"created":"2025-04-28T13:42:59.223745","updated":"2025-04-28T13:42:59.223751","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9c3c22c5-72a5-4715-8bb4-0dffeed998b1\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9c3c22c5-72a5-4715-8bb4-0dffeed998b1/pipeline.log\">pipeline</a>"]},{"id":"9dbfabfb-9ada-4397-8125-0b2276a7ad64","name":"RHEL9 - OpenShift 4 - 8.0","status":"complete","outcome":"passed","runTime":3528.812581,"created":"2025-04-28T13:43:04.213592","updated":"2025-04-28T13:43:04.213598","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9dbfabfb-9ada-4397-8125-0b2276a7ad64\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9dbfabfb-9ada-4397-8125-0b2276a7ad64/pipeline.log\">pipeline</a>"]},{"id":"334ccc75-ef99-451e-81ef-b47d4662d9a4","name":"RHEL9 - OpenShift 4 - 8.1","status":"complete","outcome":"passed","runTime":3809.491048,"created":"2025-04-28T13:43:01.870964","updated":"2025-04-28T13:43:01.870970","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/334ccc75-ef99-451e-81ef-b47d4662d9a4\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/334ccc75-ef99-451e-81ef-b47d4662d9a4/pipeline.log\">pipeline</a>"]},{"id":"30360c73-a831-44e1-aab2-42e3edb0f0cc","name":"RHEL8 - OpenShift 4 - 8.2","status":"complete","outcome":"passed","runTime":3588.284598,"created":"2025-04-28T13:43:03.788092","updated":"2025-04-28T13:43:03.788097","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/30360c73-a831-44e1-aab2-42e3edb0f0cc\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/30360c73-a831-44e1-aab2-42e3edb0f0cc/pipeline.log\">pipeline</a>"]},{"id":"83c103df-c546-4d64-acaa-62518872053b","name":"RHEL9 - OpenShift 4 - 8.2","status":"complete","outcome":"passed","runTime":3467.041008,"created":"2025-04-28T13:42:59.830164","updated":"2025-04-28T13:42:59.830170","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/83c103df-c546-4d64-acaa-62518872053b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/83c103df-c546-4d64-acaa-62518872053b/pipeline.log\">pipeline</a>"]},{"id":"2f318d44-5950-47de-a1d7-602e29502743","name":"RHEL9 - PyTest - OpenShift 4 - 8.1","status":"complete","outcome":"passed","runTime":3730.350757,"created":"2025-04-28T13:42:56.913305","updated":"2025-04-28T13:42:56.913312","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2f318d44-5950-47de-a1d7-602e29502743\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2f318d44-5950-47de-a1d7-602e29502743/pipeline.log\">pipeline</a>"]},{"id":"1c02f296-9435-455a-9417-a37ba301138b","name":"RHEL8 - PyTest - OpenShift 4 - 7.4","runTime":4258.657034,"created":"2025-04-28T13:42:56.675883","updated":"2025-04-28T13:42:56.675888","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1c02f296-9435-455a-9417-a37ba301138b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1c02f296-9435-455a-9417-a37ba301138b/pipeline.log\">pipeline</a>"]},{"id":"a33c7fc5-3c32-41b0-b3d9-f810403fd74f","name":"RHEL9 - PyTest - OpenShift 4 - 8.0","status":"complete","outcome":"passed","runTime":3186.951268,"created":"2025-04-28T11:55:43.823035","updated":"2025-04-28T11:55:43.823041","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a33c7fc5-3c32-41b0-b3d9-f810403fd74f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a33c7fc5-3c32-41b0-b3d9-f810403fd74f/pipeline.log\">pipeline</a>"]},{"id":"f5c7452c-6da6-4e42-b7b6-28e7f71f1613","name":"RHEL9 - PyTest - OpenShift 4 - 8.2","status":"complete","outcome":"passed","runTime":3677.175717,"created":"2025-04-28T13:42:57.388535","updated":"2025-04-28T13:42:57.388542","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f5c7452c-6da6-4e42-b7b6-28e7f71f1613\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f5c7452c-6da6-4e42-b7b6-28e7f71f1613/pipeline.log\">pipeline</a>"]},{"id":"5acdb482-c5ff-43a4-97de-c143c0250622","name":"RHEL8 - PyTest - OpenShift 4 - 8.2","status":"complete","outcome":"passed","runTime":3652.566718,"created":"2025-04-28T13:42:57.291741","updated":"2025-04-28T13:42:57.291746","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5acdb482-c5ff-43a4-97de-c143c0250622\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5acdb482-c5ff-43a4-97de-c143c0250622/pipeline.log\">pipeline</a>"]}]} -->