### PR TITLE
Fix regular expression for proper return 'rhel' name from 'rhel10'

### DIFF
--- a/.github/workflows/auto-merge-on-demand.yml
+++ b/.github/workflows/auto-merge-on-demand.yml
@@ -1,8 +1,8 @@
-name: Auto Merge Scheduled / On Demand
+name: Auto Merge On Demand
 on:
-  schedule:
-    # Workflow runs every 45 minutes
-    - cron: '*/45 * * * *'
+  issue_comment:
+    types:
+      - created
   workflow_dispatch:
     inputs:
       pr-number:
@@ -16,7 +16,10 @@ permissions:
 jobs:
   # Get all open PRs
   gather-pull-requests:
-    if: github.repository_owner == 'sclorg'
+    if: |
+      github.repository_owner == 'sclorg'
+      || (contains(github.event.comment.body, '/auto-merge')
+      && contains(fromJson('["OWNER", "MEMBER"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
 
     outputs:
@@ -44,7 +47,7 @@ jobs:
         name: Parse manual input
         run: |
           # shellcheck disable=SC2086
-          echo "result="[ ${{ inputs.pr-number }} ]"" >> $GITHUB_OUTPUT
+          echo "result="[ ${{ github.event.issue.number }} ]"" >> $GITHUB_OUTPUT
         shell: bash
 
   validate-pr:

--- a/test/test-lib-php.sh
+++ b/test/test-lib-php.sh
@@ -20,7 +20,7 @@ function test_php_integration() {
 
 # Check the imagestream
 function test_php_imagestream() {
-  ct_os_test_image_stream_s2i "${THISDIR}/imagestreams/php-${OS%[0-9]*}.json" "${IMAGE_NAME}" \
+  ct_os_test_image_stream_s2i "${THISDIR}/imagestreams/php-${OS//[0-9]/}.json" "${IMAGE_NAME}" \
                               "https://github.com/sclorg/s2i-php-container.git" \
                               test/test-app \
                               "Test PHP passed"


### PR DESCRIPTION
Fix regular expression for proper return 'rhel' name from 'rhel10'

All expression returns 'rhel1'. The new expression returns proper name

<!-- issue-commentator = {"comment-id":"2965822771"} -->

<!-- testing-farm = {"lock":"false","comment-id":"2965910902","data":[{"id":"ef78385a-1c50-47b5-933f-a765b14dd3c1","name":"RHEL9 - OpenShift 4 - 8.0","status":"complete","outcome":"passed","runTime":1199.292435,"created":"2025-06-12T09:24:50.426241","updated":"2025-06-12T09:24:50.426254","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ef78385a-1c50-47b5-933f-a765b14dd3c1\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ef78385a-1c50-47b5-933f-a765b14dd3c1/pipeline.log\">pipeline</a>"]},{"id":"7eeafb01-ba5d-4ddb-ae2a-6bc584db754f","name":"RHEL8 - OpenShift 4 - 7.4","status":"complete","outcome":"passed","runTime":1142.372943,"created":"2025-06-12T09:35:36.569537","updated":"2025-06-12T09:35:36.569543","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7eeafb01-ba5d-4ddb-ae2a-6bc584db754f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7eeafb01-ba5d-4ddb-ae2a-6bc584db754f/pipeline.log\">pipeline</a>"]},{"id":"d490d7ba-df47-4623-9e3f-2a3028479cc1","name":"RHEL8 - OpenShift 4 - 8.2","status":"complete","outcome":"passed","runTime":1127.43823,"created":"2025-06-12T09:52:10.208559","updated":"2025-06-12T09:52:10.208566","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d490d7ba-df47-4623-9e3f-2a3028479cc1\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d490d7ba-df47-4623-9e3f-2a3028479cc1/pipeline.log\">pipeline</a>"]},{"id":"08ae1e58-e203-44d6-ac13-39d9d6a564f5","name":"RHEL9 - OpenShift 4 - 8.1","status":"complete","outcome":"passed","runTime":1281.944601,"created":"2025-06-12T09:51:44.012830","updated":"2025-06-12T09:51:44.012837","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/08ae1e58-e203-44d6-ac13-39d9d6a564f5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/08ae1e58-e203-44d6-ac13-39d9d6a564f5/pipeline.log\">pipeline</a>"]},{"id":"0fd96356-f1cf-4f2d-a4c1-12b4ae0a94cd","name":"RHEL9 - OpenShift 4 - 8.2","status":"complete","outcome":"passed","runTime":1273.372931,"created":"2025-06-12T09:51:56.638357","updated":"2025-06-12T09:51:56.638363","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0fd96356-f1cf-4f2d-a4c1-12b4ae0a94cd\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0fd96356-f1cf-4f2d-a4c1-12b4ae0a94cd/pipeline.log\">pipeline</a>"]},{"id":"b31fa08b-3d59-4879-bf91-fc8da8e4f00a","name":"RHEL8 - PyTest - OpenShift 4 - 8.2","status":"complete","outcome":"passed","runTime":1411.20712,"created":"2025-06-12T10:33:33.098618","updated":"2025-06-12T10:33:33.098624","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b31fa08b-3d59-4879-bf91-fc8da8e4f00a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b31fa08b-3d59-4879-bf91-fc8da8e4f00a/pipeline.log\">pipeline</a>"]},{"id":"56775b2d-149d-4717-87e3-bbbfe8badd94","name":"RHEL8 - PyTest - OpenShift 4 - 7.4","status":"complete","outcome":"passed","runTime":1341.592696,"created":"2025-06-12T10:33:32.210042","updated":"2025-06-12T10:33:32.210048","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/56775b2d-149d-4717-87e3-bbbfe8badd94\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/56775b2d-149d-4717-87e3-bbbfe8badd94/pipeline.log\">pipeline</a>"]},{"id":"3fbe57c9-6027-40f5-8139-8e2e588aabfc","name":"RHEL9 - PyTest - OpenShift 4 - 8.1","status":"complete","outcome":"passed","runTime":1518.419329,"created":"2025-06-12T10:33:32.090065","updated":"2025-06-12T10:33:32.090071","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3fbe57c9-6027-40f5-8139-8e2e588aabfc\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3fbe57c9-6027-40f5-8139-8e2e588aabfc/pipeline.log\">pipeline</a>"]},{"id":"c7cdcd2d-6256-4055-a543-717034219240","name":"RHEL9 - PyTest - OpenShift 4 - 8.0","status":"complete","outcome":"passed","runTime":1530.926925,"created":"2025-06-12T10:33:34.802810","updated":"2025-06-12T10:33:34.802816","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c7cdcd2d-6256-4055-a543-717034219240\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c7cdcd2d-6256-4055-a543-717034219240/pipeline.log\">pipeline</a>"]},{"id":"a73cbfbc-9af5-4f66-abc2-7cf2f8a365d1","name":"RHEL9 - PyTest - OpenShift 4 - 8.2","runTime":1630.949368,"created":"2025-06-12T10:33:33.698673","updated":"2025-06-12T10:33:33.698679","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a73cbfbc-9af5-4f66-abc2-7cf2f8a365d1\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a73cbfbc-9af5-4f66-abc2-7cf2f8a365d1/pipeline.log\">pipeline</a>"]}]} -->