### PR TITLE
Do not test PHP Openshift tests

### DIFF
--- a/test/test-lib-php.sh
+++ b/test/test-lib-php.sh
@@ -35,7 +35,7 @@ function test_php_template() {
     BRANCH_TO_TEST="4.X"
     check_msg="Welcome to CakePHP 4.5"
   # Version 8.1 is supported only for RHEL9
-  elif [ "${VERSION}" == "8.1" ] || [ "${VERSION}" == "8.2" ] || [ "${VERSION}" == "8.3" ]; then
+  elif [ "${VERSION}" == "8.2" ] || [ "${VERSION}" == "8.3" ]; then
     supported_use_case="True"
     BRANCH_TO_TEST="5.X"
     check_msg="Welcome to CakePHP 5"

--- a/test/test_php_deploy_templates.py
+++ b/test/test_php_deploy_templates.py
@@ -19,7 +19,7 @@ OS = os.getenv("TARGET")
 if VERSION == "7.4" or VERSION == "8.0":
     branch_to_test = "4.X"
     check_msg = "Welcome to CakePHP"
-elif VERSION == "8.1" or VERSION == "8.2" or VERSION == "8.3":
+elif VERSION == "8.2" or VERSION == "8.3":
     branch_to_test = "5.X"
     check_msg = "Welcome to CakePHP"
 else:

--- a/test/test_shared_helm_cakephp_application.py
+++ b/test/test_shared_helm_cakephp_application.py
@@ -34,7 +34,7 @@ TAG = TAGS.get(OS)
 class TestHelmCakePHPTemplate:
 
     def setup_method(self):
-        package_name = "redhat-php-cakephp-application"
+        package_name = "redhat-cakephp-application-template"
         path = test_dir
         self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
         self.hc_api.clone_helm_chart_repo(
@@ -54,7 +54,7 @@ class TestHelmCakePHPTemplate:
         self.hc_api.package_name = "redhat-php-imagestreams"
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation()
-        self.hc_api.package_name = "redhat-php-cakephp-application"
+        self.hc_api.package_name = "redhat-cakephp-application-template"
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation(
             values={

--- a/test/test_shared_helm_cakephp_application.py
+++ b/test/test_shared_helm_cakephp_application.py
@@ -23,7 +23,7 @@ OS = os.getenv("TARGET")
 
 if VERSION == "7.4" or VERSION == "8.0":
     check_msg = "Welcome to CakePHP"
-elif VERSION == "8.1" or VERSION == "8.2" or VERSION == "8.3":
+elif  VERSION == "8.2" or VERSION == "8.3":
     check_msg = "Welcome to CakePHP"
 else:
     check_msg = "Welcome to your CakePHP application on OpenShift"

--- a/test/test_shared_helm_chart_imagestreams.py
+++ b/test/test_shared_helm_chart_imagestreams.py
@@ -36,7 +36,7 @@ class TestHelmRHELPHPImageStreams:
             ("8.3-ubi9", "registry.redhat.io/ubi9/php-83:latest", True),
             ("8.2-ubi9", "registry.redhat.io/ubi9/php-82:latest", True),
             ("8.2-ubi8", "registry.redhat.io/ubi8/php-82:latest", True),
-            ("8.1-ubi9", "registry.redhat.io/ubi9/php-81:latest", True),
+            ("8.1-ubi9", "registry.redhat.io/ubi9/php-81:latest", False),
             ("8.0-ubi9", "registry.redhat.io/ubi9/php-80:latest", True),
             ("8.0-ubi8", "registry.redhat.io/ubi8/php-80:latest", False),
             ("7.4-ubi8", "registry.redhat.io/ubi8/php-74:latest", True),


### PR DESCRIPTION
It reached EOL in May 2025.

<!-- issue-commentator = {"comment-id":"3028150510"} -->

<!-- testing-farm = {"lock":"false","comment-id":"3028414468","data":[{"id":"f438142e-830a-4c75-9d3f-714c8eb20a91","name":"RHEL8 - OpenShift 4 - 8.2","status":"complete","outcome":"passed","runTime":1362.756254,"created":"2025-07-03T07:58:18.094692","updated":"2025-07-03T07:58:18.094699","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f438142e-830a-4c75-9d3f-714c8eb20a91\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f438142e-830a-4c75-9d3f-714c8eb20a91/pipeline.log\">pipeline</a>"]},{"id":"c53fefb1-1108-42af-aad2-9a8a39eb7da4","name":"RHEL9 - PyTest - OpenShift 4 - 8.2","status":"complete","outcome":"passed","runTime":1790.170376,"created":"2025-07-03T07:58:06.782008","updated":"2025-07-03T07:58:06.782016","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c53fefb1-1108-42af-aad2-9a8a39eb7da4\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c53fefb1-1108-42af-aad2-9a8a39eb7da4/pipeline.log\">pipeline</a>"]},{"id":"045f933f-2c0e-415a-8bd5-ea5d2d4406a5","name":"RHEL9 - OpenShift 4 - 8.0","status":"complete","outcome":"passed","runTime":1564.769848,"created":"2025-07-03T07:58:18.245970","updated":"2025-07-03T07:58:18.245978","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/045f933f-2c0e-415a-8bd5-ea5d2d4406a5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/045f933f-2c0e-415a-8bd5-ea5d2d4406a5/pipeline.log\">pipeline</a>"]},{"id":"b4077266-97e8-4c46-86cc-124e85be3f22","name":"RHEL8 - PyTest - OpenShift 4 - 7.4","status":"complete","outcome":"passed","runTime":1421.299187,"created":"2025-07-03T07:58:08.598631","updated":"2025-07-03T07:58:08.598637","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b4077266-97e8-4c46-86cc-124e85be3f22\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b4077266-97e8-4c46-86cc-124e85be3f22/pipeline.log\">pipeline</a>"]},{"id":"ece53110-27b9-4d53-ad77-cc5609646eb6","name":"RHEL9 - OpenShift 4 - 8.1","status":"complete","outcome":"passed","runTime":1783.376554,"created":"2025-07-03T06:48:56.796701","updated":"2025-07-03T06:48:56.796707","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ece53110-27b9-4d53-ad77-cc5609646eb6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ece53110-27b9-4d53-ad77-cc5609646eb6/pipeline.log\">pipeline</a>"]},{"id":"30771981-f02f-42bc-bed0-7980d9f501de","name":"RHEL9 - PyTest - OpenShift 4 - 8.1","status":"complete","outcome":"error","runTime":1408.67071,"created":"2025-07-03T06:49:02.741539","updated":"2025-07-03T06:49:02.741545","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/30771981-f02f-42bc-bed0-7980d9f501de\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/30771981-f02f-42bc-bed0-7980d9f501de/pipeline.log\">pipeline</a>"]},{"id":"665dcfc9-5145-4c15-a24f-d0d097bfd022","name":"RHEL9 - OpenShift 4 - 8.2","status":"complete","outcome":"passed","runTime":1530.886774,"created":"2025-07-03T07:58:21.091699","updated":"2025-07-03T07:58:21.091704","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/665dcfc9-5145-4c15-a24f-d0d097bfd022\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/665dcfc9-5145-4c15-a24f-d0d097bfd022/pipeline.log\">pipeline</a>"]},{"id":"d2b2146a-12c0-4102-9a77-43d380af0139","name":"RHEL9 - PyTest - OpenShift 4 - 8.0","runTime":1832.543119,"created":"2025-07-03T07:58:06.172957","updated":"2025-07-03T07:58:06.172962","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d2b2146a-12c0-4102-9a77-43d380af0139\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d2b2146a-12c0-4102-9a77-43d380af0139/pipeline.log\">pipeline</a>"]},{"id":"23738113-685c-4cfe-a168-92d03b192fd2","name":"RHEL8 - PyTest - OpenShift 4 - 8.2","status":"complete","outcome":"passed","runTime":1599.953255,"created":"2025-07-03T07:58:08.230315","updated":"2025-07-03T07:58:08.230322","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/23738113-685c-4cfe-a168-92d03b192fd2\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/23738113-685c-4cfe-a168-92d03b192fd2/pipeline.log\">pipeline</a>"]},{"id":"26789f2a-e32b-4841-84c8-07d3389ec774","name":"RHEL8 - OpenShift 4 - 7.4","status":"complete","outcome":"passed","runTime":1232.03114,"created":"2025-07-03T07:58:17.894954","updated":"2025-07-03T07:58:17.894960","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/26789f2a-e32b-4841-84c8-07d3389ec774\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/26789f2a-e32b-4841-84c8-07d3389ec774/pipeline.log\">pipeline</a>"]},{"id":"dcf3de02-ab03-4549-abdb-30ca17530475","name":"RHEL10 - OpenShift 4 - 8.3","status":"complete","outcome":"passed","runTime":1003.763869,"created":"2025-07-03T07:58:18.269864","updated":"2025-07-03T07:58:18.269872","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/dcf3de02-ab03-4549-abdb-30ca17530475\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/dcf3de02-ab03-4549-abdb-30ca17530475/pipeline.log\">pipeline</a>"]},{"id":"496a576a-5ee8-41be-a032-c3239aae0b90","name":"RHEL10 - PyTest - OpenShift 4 - 8.3","status":"complete","outcome":"passed","runTime":1248.999554,"created":"2025-07-03T07:58:05.554142","updated":"2025-07-03T07:58:05.554151","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/496a576a-5ee8-41be-a032-c3239aae0b90\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/496a576a-5ee8-41be-a032-c3239aae0b90/pipeline.log\">pipeline</a>"]},{"id":"d4fccbec-acb7-4df3-9090-6af91ed5c06b","name":"RHEL9 - OpenShift 4 - 8.3","status":"complete","outcome":"passed","runTime":1250.098302,"created":"2025-07-03T07:58:18.404781","updated":"2025-07-03T07:58:18.404789","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d4fccbec-acb7-4df3-9090-6af91ed5c06b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d4fccbec-acb7-4df3-9090-6af91ed5c06b/pipeline.log\">pipeline</a>"]},{"id":"27f906e1-005a-4f77-acf6-86f4b09d8529","name":"RHEL9 - PyTest - OpenShift 4 - 8.3","status":"complete","outcome":"passed","runTime":1714.338316,"created":"2025-07-03T07:58:06.029152","updated":"2025-07-03T07:58:06.029163","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/27f906e1-005a-4f77-acf6-86f4b09d8529\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/27f906e1-005a-4f77-acf6-86f4b09d8529/pipeline.log\">pipeline</a>"]}]} -->