### PR TITLE
Remove 'version' label from Dockerfile.rhel10

### DIFF
--- a/8.3/Dockerfile.rhel10
+++ b/8.3/Dockerfile.rhel10
@@ -34,7 +34,6 @@ LABEL summary="${SUMMARY}" \
       io.s2i.scripts-url="image:///usr/libexec/s2i" \
       name="ubi10/${NAME}-${PHP_VER_SHORT}" \
       com.redhat.component="${NAME}-${PHP_VER_SHORT}-container" \
-      version="1" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI" \
       help="For more information visit https://github.com/sclorg/s2i-${NAME}-container" \
       usage="s2i build https://github.com/sclorg/s2i-php-container.git --context-dir=${PHP_VERSION}/test/test-app ubi10/${NAME}-${PHP_VER_SHORT} sample-server" \


### PR DESCRIPTION
Remove 'version' label from Dockerfile.rhel10

Konflux build pipeline needs it.
See https://issues.redhat.com/browse/RHELMISC-17288

<!-- issue-commentator = {"comment-id":"3279393385"} -->

<!-- testing-farm = {"lock":"false","comment-id":"3279620537","data":[{"id":"655e0228-e38e-4537-8a1b-5838691a1482","name":"Fedora - 8.2","status":"complete","outcome":"passed","runTime":428.894524,"created":"2025-09-11T09:46:04.623166","updated":"2025-09-11T09:46:04.623172","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/655e0228-e38e-4537-8a1b-5838691a1482\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/655e0228-e38e-4537-8a1b-5838691a1482/pipeline.log\">pipeline</a>"]},{"id":"5d87d666-359e-49ec-830e-150d48a3fa8b","name":"Fedora - 8.3","status":"complete","outcome":"passed","runTime":424.432161,"created":"2025-09-11T09:52:35.164600","updated":"2025-09-11T09:52:35.164608","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/5d87d666-359e-49ec-830e-150d48a3fa8b\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/5d87d666-359e-49ec-830e-150d48a3fa8b/pipeline.log\">pipeline</a>"]},{"id":"6f64fc30-c5d6-4abe-867f-14d6aa13ddab","name":"RHEL9 - 8.0","status":"complete","outcome":"passed","runTime":1228.699018,"created":"2025-09-11T09:48:22.942823","updated":"2025-09-11T09:48:22.942833","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6f64fc30-c5d6-4abe-867f-14d6aa13ddab\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6f64fc30-c5d6-4abe-867f-14d6aa13ddab/pipeline.log\">pipeline</a>"]},{"id":"db0e9640-8f32-462b-b8b4-50de2f140754","name":"RHEL9 - 8.2","status":"complete","outcome":"passed","runTime":1155.006609,"created":"2025-09-11T09:58:22.861555","updated":"2025-09-11T09:58:22.861563","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/db0e9640-8f32-462b-b8b4-50de2f140754\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/db0e9640-8f32-462b-b8b4-50de2f140754/pipeline.log\">pipeline</a>"]},{"id":"45e41522-06dd-41ac-b0f6-a0e742cfdc0c","name":"CentOS Stream 10 - 8.3","status":"complete","outcome":"passed","runTime":509.300938,"created":"2025-09-11T10:10:44.163154","updated":"2025-09-11T10:10:44.163161","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/45e41522-06dd-41ac-b0f6-a0e742cfdc0c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/45e41522-06dd-41ac-b0f6-a0e742cfdc0c/pipeline.log\">pipeline</a>"]},{"id":"1ba789e8-4a97-4091-87d1-36f01e5b3735","name":"RHEL10 - 8.3","status":"complete","outcome":"passed","runTime":887.149451,"created":"2025-09-11T10:04:47.258220","updated":"2025-09-11T10:04:47.258229","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1ba789e8-4a97-4091-87d1-36f01e5b3735\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1ba789e8-4a97-4091-87d1-36f01e5b3735/pipeline.log\">pipeline</a>"]},{"id":"b1069798-ac9a-44ff-ab75-cb6f0d38c0a0","name":"RHEL8 - 8.2","status":"complete","outcome":"passed","runTime":906.317038,"created":"2025-09-11T10:10:48.164175","updated":"2025-09-11T10:10:48.164186","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b1069798-ac9a-44ff-ab75-cb6f0d38c0a0\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b1069798-ac9a-44ff-ab75-cb6f0d38c0a0/pipeline.log\">pipeline</a>"]},{"id":"db577de3-c352-41be-81e9-53fc11faa406","name":"CentOS Stream 9 - 8.3","status":"complete","outcome":"passed","runTime":636.300825,"created":"2025-09-11T10:15:17.965705","updated":"2025-09-11T10:15:17.965712","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/db577de3-c352-41be-81e9-53fc11faa406\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/db577de3-c352-41be-81e9-53fc11faa406/pipeline.log\">pipeline</a>"]},{"id":"46bf6e38-c404-404d-87c8-740a9e4955c0","name":"RHEL8 - 7.4","status":"complete","outcome":"passed","runTime":907.969488,"created":"2025-09-11T10:15:03.188237","updated":"2025-09-11T10:15:03.188243","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/46bf6e38-c404-404d-87c8-740a9e4955c0\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/46bf6e38-c404-404d-87c8-740a9e4955c0/pipeline.log\">pipeline</a>"]},{"id":"51e09739-e443-4c70-98fc-4565462b511f","name":"RHEL9 - 8.3","runTime":1173.840725,"created":"2025-09-11T10:15:41.179128","updated":"2025-09-11T10:15:41.179137","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/51e09739-e443-4c70-98fc-4565462b511f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/51e09739-e443-4c70-98fc-4565462b511f/pipeline.log\">pipeline</a>"]}]} -->